### PR TITLE
DCC UI Rebuild v1 — design system + senior-accessible redesign

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# AGENTS.md — Digital Confidence Centre
+
+This file governs **every** automated/agent run in this repository. Read it
+before changing anything. It is the single source of truth for what we are
+building, who it is for, how it must look and behave, and what "done" means.
+If this file and a task instruction disagree, follow this file unless the human
+(Aaron) explicitly overrides it.
+
+> Companion docs: `PRODUCT.md` (audience & voice), `DESIGN-SYSTEM.md` (token &
+> component decisions), `_audit/ui-ux-ia-audit-2026-06-18.md` (current-state
+> audit), `styleguide/SENIOR-ACCESSIBLE-RESEARCH-2026.md` (design research).
+
+---
+
+## Product
+
+The **Digital Confidence Centre (DCC)** is a free, bilingual (English / French)
+digital-literacy platform. It teaches Canadian seniors to use phones, tablets,
+and the internet safely and confidently, and it gives the libraries, nonprofits,
+and settlement agencies who serve them ready-to-run, no-cost material. ~30
+self-paced modules cover device basics, scam protection, online banking, video
+calling, AI literacy, and Canadian government services (CRA, Service Canada,
+provincial benefits). No account, no tracking, no cost.
+
+## Target users
+
+1. **Primary — older adults (65+/70+).** Low digital confidence, often anxious,
+   reading with glasses, on an iPad/iPhone/Android tablet, frequently in dark
+   mode, frequently interrupted, returning over weeks. Many are "not behind —
+   just getting started."
+2. **Caregivers (adult children 40–60)** setting up a device for a parent.
+3. **Community organisations** — library facilitators running 90-minute group
+   sessions, nonprofit and settlement-agency staff. They need print-ready,
+   plain-language, no-login material.
+
+Success = a 70-year-old who was afraid of their phone can recognise a scam,
+video-call family, and check a government account without phoning their kids.
+
+## Design principles (in priority order)
+
+1. **Anxiety first.** The first message on any screen reassures before it
+   instructs. Never use "wrong / failed / incorrect / error" as user-facing
+   feedback — use "let's try again", "not quite — here's a hint", "good try".
+2. **One thing per screen.** No competing calls to action; navigation recedes.
+3. **Dark mode is not an afterthought.** Test it first. All text passes AA in
+   both light and dark.
+4. **Floating elements earn their place.** Nothing hovers over readable content.
+5. **Always a way back.** Every page has an obvious Home link.
+6. **Plain language, Canadian English.** Short sentences (≤20 words), one idea
+   each. centre/colour/recognise, never -ize. Action verbs on every button.
+7. **Token-driven, never ad-hoc.** No hardcoded hex/px in page markup — use the
+   design tokens.
+
+## Tech stack & hard constraints
+
+- **Static only.** Flat HTML/CSS/JS served from GitHub Pages + Cloudflare. No
+  Node server, no npm build step, no backend, no framework, no bundler.
+- **Progressive enhancement.** HTML works without JS; CSS and JS are additive.
+- **Forms → Formspree** (`https://formspree.io/f/xeerqryj`), with Web3Forms as a
+  silent fallback. **Never** call the GitHub Issues API from the browser (no
+  CORS). LocalStorage is an offline queue only, never the primary submit path.
+- **Styling pipeline (load order):**
+  `main.css → tokens.css → tokens-dark.css → fonts.css → components.css →
+  accessibility.css → mobile.css → dcc-core.css`.
+  - `css/tokens.css` — single source of truth for colour/type/spacing/etc.
+  - `css/tokens-dark.css`, `css/tokens-high-contrast.css` — theme overrides
+    (same variable names).
+  - `css/components.css` — structural "bones", token-only.
+  - `css/dcc-core.css` — production refinement layer (loaded last). Put new
+    cross-page UI here, token-driven, prefixed `.dcc-`.
+- **Self-hosted fonts:** Merriweather (body) + Source Sans 3 (headings), SIL OFL.
+- **Do not change module learning content** (lesson copy/quizzes). UI, layout,
+  and form logic only, unless explicitly told otherwise.
+- **Preserve JS hooks:** `.font-size-btn`, `.theme-toggle-btn`, `.menu-btn`,
+  `.sidebar`, `.module-card[data-module]`, `[data-en]/[data-fr]`, and the
+  homepage data IDs (`#whats-new-cards`, `#sotm-*`, `#dcc-news-list`). Restyle
+  with classes; never rename hooks.
+
+## Accessibility bar (must hold)
+
+- **WCAG 2.2 AA** on all new/changed UI (AODA Ontario requires 2.2 AA by 2027).
+- Body text ≥ 18px (DCC base is 19px); fully usable at 200% zoom / 320px reflow.
+- Touch targets ≥ 44px (DCC default 56px for primary actions).
+- Focus always visible: `--focus-ring` (3px `--color-accent-strong`, 2px offset).
+- **Never** use `--color-accent` (`#E8842C`) as a text or button background —
+  white-on-it is 2.7:1. Use `--color-accent-strong` (`#A85410`, 5.33:1).
+- No italics, no justified text, no centre-aligned prose. Left-align.
+- Respect `prefers-reduced-motion` (tokens zero the durations).
+- Close buttons: plain `✕ Close` text button, top-right — never a red circle.
+
+### Checking contrast (run before committing colour changes)
+```bash
+python3 - <<'PY'
+def lin(c):
+    c/=255; return c/12.92 if c<=0.03928 else ((c+0.055)/1.055)**2.4
+def L(h):
+    h=h.lstrip('#'); r,g,b=int(h[0:2],16),int(h[2:4],16),int(h[4:6],16)
+    return .2126*lin(r)+.7152*lin(g)+.0722*lin(b)
+def ratio(a,b):
+    la,lb=L(a),L(b); hi,lo=max(la,lb),min(la,lb); return round((hi+.05)/(lo+.05),2)
+print(ratio('#FFFFFF','#A85410'))  # must be >= 4.5 for body, >= 3 for large/UI
+PY
+```
+
+## Localisation
+
+- Canadian English everywhere (Centre, Colour, Labour, recognise, behaviour).
+- Bilingual EN/FR via `[data-en]/[data-fr]`. When French is unavailable, expose
+  the link and add `(English only)` — never hide it. Infer language from
+  `navigator.language`; no language-selector field on forms.
+- Default city: St. Thomas, Ontario; Ontario-specific resources where relevant.
+
+## Workflow
+
+- Branch from `main` as `cursor/<descriptive-name>`; commit per logical change
+  with `feat(dcc): / fix(dcc): / chore(dcc):` messages; open a PR (draft by
+  default). Do not force-push, amend, or merge unless told to.
+- Keep changes non-destructive: preserve SEO `<head>`, schema JSON-LD, canonical
+  /hreflang links, and existing navigation links.
+
+## What "done" looks like
+
+A change is done when **all** of these hold:
+
+- [ ] Renders correctly in light **and** dark mode, and at 200% zoom / 320px.
+- [ ] All text, buttons, focus states meet WCAG 2.2 AA contrast (verified).
+- [ ] No hardcoded hex/px in the page — only tokens / token-driven classes.
+- [ ] Touch targets ≥ 44px; primary actions ≥ 56px; focus ring visible.
+- [ ] Plain Canadian English; reassuring, non-blaming microcopy; action-verb buttons.
+- [ ] Keyboard-operable; semantic headings (no skipped levels); ARIA on icon-only controls.
+- [ ] No new external dependency, no build step, no backend call from the browser.
+- [ ] JS hooks and IDs preserved; existing links and SEO intact.
+- [ ] EN/FR parity (or `(English only)` noted); Formspree submit path works.
+- [ ] Committed with a clear message; PR opened/updated.

--- a/DESIGN-SYSTEM.md
+++ b/DESIGN-SYSTEM.md
@@ -54,7 +54,7 @@ All values live in `css/tokens.css`. Never hardcode a hex, px, or rem outside a 
 | `--color-success-light` | `#E8F5E9` | Success state backgrounds |
 | `--color-success-deep` | `#1B5E20` | Success text-on-light |
 
-**Do not use `--color-accent` (#E8842C) as text colour on white** — it is 3.1:1 against #FAFAF8 (AA large only). Use `--color-accent-deep` (`#8A450C`) for orange text.
+**Do not use `--color-accent` (#E8842C) as text colour on white** — white-on-#E8842C is only 2.7:1 (fails even large text). `--color-accent` is **decorative only** (progress fills, large icons, borders, hero flourishes). For orange **text** on light fills use `--color-accent-deep` (`#8A450C`). For **button/CTA backgrounds and the focus ring** use `--color-accent-strong` (`#A85410`, white text = 5.33:1, AA).
 
 ### Typography Tokens in Practice
 
@@ -421,6 +421,8 @@ Before pushing any new or revised module page:
 | `css/tokens-dark.css` | Dark mode token overrides |
 | `css/tokens-high-contrast.css` | High-contrast token overrides |
 | `css/components.css` | Component structure (bones) — no colour hardcodes |
+| `css/dcc-core.css` | Production refinement layer, loaded LAST. New cross-page UI (`.dcc-callout`, `.dcc-btn`, marketing primitives, `.dcc-top--*`) lives here — token-driven, prefixed `.dcc-` |
+| `AGENTS.md` | Governs every agent run: product, users, principles, stack, "done" checklist |
 | `css/fonts.css` | Self-hosted Merriweather + Source Sans 3 (SIL OFL licensed — `fonts/LICENSE-OFL.txt`) |
 | `styleguide/index.html` | Live component showcase (canonical visual reference) |
 | `styleguide/COMPETITIVE-AUDIT.md` | Five content-competitor platforms reviewed April 2026 |

--- a/_audit/ui-ux-ia-audit-2026-06-18.md
+++ b/_audit/ui-ux-ia-audit-2026-06-18.md
@@ -1,0 +1,170 @@
+# DCC UI / UX / IA Audit — 2026-06-18
+
+Audit performed at the start of the **DCC UI Rebuild v1** sprint. This documents
+what exists today (pages, components, layout, CSS/JS architecture, information
+architecture) and the findings that drive the rebuild. Findings-and-inventory
+only — fixes are tracked in the rebuild PR.
+
+---
+
+## 1. Inventory (counts)
+
+| Thing | Count | Notes |
+|---|---|---|
+| HTML files (total) | 333 | includes generated geo/answers/tips pages |
+| HTML files (repo root) | 74 | the hand-built pages |
+| Module pages (`module-*.html`) | 37 | 24 numbered + named bonus modules |
+| CSS files (`css/`) | 19 | `main.css` is 168 KB and dominant |
+| JS files (`js/`) | 74 | progressive-enhancement helpers |
+| Inline `style=` on `index.html` | 74 | many off-token |
+| Hardcoded hex on `for-libraries.html` | 65 | page has its own private palette |
+
+### Page groups
+- **Marketing / entry:** `index.html`, `about.html`, `whats-coming.html`, `demographics.html`
+- **Learning:** `digital-literacy-101.html`, `module-1..24`, named bonus modules, `final-quiz.html`, `scam-simulator.html`
+- **Audience landing:** `for-libraries.html`, `family.html`, `family-setup.html`, `institutional.html`, `b2b/`, `kids/`
+- **Resources:** `resources.html`, `resources/*`, `recommended-tools.html`, `print-centre.html`, `glossary.html`, `faq.html`, `answers/*`, `tips/*`
+- **Account-less utility:** `accessibility.html`, `accessibility/*`, `privacy.html`, `terms.html`, `certificate.html`
+- **Internal / ops:** `admin/*`, `_*` working directories, `backlog-dashboard.html`
+
+---
+
+## 2. CSS architecture
+
+Load order on most shared pages:
+
+```
+main.css → tokens.css → tokens-dark.css → fonts.css → components.css
+→ accessibility.css → mobile.css
+```
+
+- **`tokens.css`** (v1 before this sprint): a genuinely strong "Warm Hearth"
+  token set — surfaces, brand, text, state, spacing (4px scale), radius,
+  shadow, motion, focus, touch targets, plus a *legacy namespace bridge* that
+  maps old `main.css` variable names (`--bg-primary`, `--brand-teal`, …) onto
+  the canonical tokens. This bridge is load-bearing: ~200 pages depend on it.
+- **`main.css`** (168 KB): the legacy workhorse. Defines `.welcome-hero`,
+  `.module-card`, `.sidebar`, `.site-footer`, etc. Mixes token references with
+  some hardcoded values. Too large and intertwined to safely rewrite in one
+  pass.
+- **`components.css`** (36 KB): cleaner "bones" layer, token-only, documents
+  reset → a11y utils → typography → layout → nav → buttons → forms → cards →
+  content blocks → quiz → progress → feedback → footer.
+- **`tokens-dark.css` / `tokens-high-contrast.css`**: theme overrides with the
+  same variable names. Verified AA pairs in comments.
+- **`tokens-alt.css`**: empty white-label template (partner theming).
+
+### Finding C-1 — accent orange fails as a text/button colour
+`--color-accent` (`#E8842C`) is used for primary CTAs with white text, but
+white-on-`#E8842C` is **2.70:1** — below the WCAG 1.4.3 / 1.4.11 / 2.4.13
+threshold (3:1) even for large/bold text. This is the single most impactful
+contrast defect. **Rebuild fix:** added `--color-accent-strong` (`#A85410`,
+5.33:1) for all button/CTA backgrounds and the focus ring; demoted
+`--color-accent` to decorative use only.
+
+### Finding C-2 — heavy inline styling drifts off-token
+`index.html` alone carries 74 inline `style=` attributes, many with raw hex
+(`#fff3f3`, `#c0392b`, `#f0f6ff`, `#E8F5E9`, `#1B5E20`, border-top swatches on
+benefit cards). These ad-hoc colours are what make sections look "generic" and
+inconsistent, and they cannot be re-skinned by theme or dark-mode tokens (inline
+wins the cascade). **Rebuild fix:** new `dcc-core.css` `.dcc-callout` component +
+`.dcc-top--*` accents replace the worst offenders with token-driven classes.
+
+### Finding C-3 — `for-libraries.html` is a parallel design system
+This page defines its **own** `:root` palette (`--navy`, `--blue`, `--slate-*`,
+`--green`), system-font stack, 16px base, and 1.6 line-height — none of it
+shares the Warm Hearth tokens, fonts, accessibility bar, nav, or dark mode. It
+looks like a different product. **Rebuild fix:** fully rebuilt onto the shared
+token stack + `dcc-core.css` marketing primitives.
+
+---
+
+## 3. Component inventory (existing, reusable)
+
+Defined in `main.css` / `components.css` and used across pages:
+
+- **Navigation:** `.accessibility-bar` (text size A/A/A/A + theme toggle),
+  `.top-bar` (mobile), `.sidebar` + `.sidebar-overlay` + `.snav-group`
+  (collapsible grouped nav), `.skip-link`, `.site-footer` + `.footer-links`.
+- **Cards:** `.module-grid`, `.module-card` (icon + content + badge + progress).
+- **Content blocks:** `.story-block`, `.tip-block` / `.tip-box`,
+  `.warning-block`, `.confidence-check`, `.alert-card`, `.trust-signals` /
+  `.trust-item`, `.eeat-trust-bar`.
+- **Hero:** `.welcome-hero` (text + image, class-based — good).
+- **Social proof:** `.testimonials-section` / `.testimonial-card`.
+- **Quiz:** `.quiz-block`, `.quiz-option`, `.quiz-feedback` (aria-live).
+- **Misc:** `.podcast-card`, `.email-invite-box`, `.progress-overview`,
+  `.module-nav`.
+
+These are sound and are **kept**. The rebuild adds a thin token-driven layer
+rather than replacing them.
+
+---
+
+## 4. JavaScript / behaviour (hooks to preserve)
+
+Accessibility and personalisation depend on specific class names / IDs that the
+rebuild must not break:
+
+- `accessibility.js`, `settings.js` → `.font-size-btn[data-size]`,
+  `.theme-toggle-btn`, `html.text-size-*`, `data-theme`.
+- `app.js` → `.menu-btn`, `.sidebar`, `.sidebar-overlay`, `.sidebar-close`.
+- `module-grid.js`, `progress.js` → `.module-card[data-module]`,
+  `.progress-bar-fill`, `#dcc-progress-widget`.
+- `lang-toggle.js`, `localize.js` → `[data-en]/[data-fr]`, `data-lang`.
+- Homepage data widgets fetch JSON and write into `#whats-new-cards`,
+  `#scam-of-the-month` (`#sotm-*`), `#dcc-news-list`. IDs must be preserved.
+
+**Rebuild rule:** keep all hook names and IDs; restyle via classes only.
+
+---
+
+## 5. Information architecture
+
+Primary nav (sidebar) is grouped into **Get Started / All Lessons / Resources &
+Help**, plus an accessibility section. This grouping is good and matches the
+2026-06-17 IA audit (`ia-audit-2026-06-17.md`).
+
+Observations carried into the rebuild:
+- **Two audiences, one front door.** Seniors (learners) and community
+  organisations (libraries, nonprofits, settlement agencies) both land on
+  `index.html`. The org path (`for-libraries.html`) is reachable but visually
+  disconnected. The rebuild keeps a clear, plain-language split.
+- **Escape hatch.** A persistent, obvious Home link exists (design principle 5)
+  — preserved.
+- **Module ordering** is curated (1 → 24 + "Expanding Your Horizons" divider).
+  Left intact; this is content, not chrome.
+
+---
+
+## 6. Accessibility baseline (today)
+
+Strengths: skip link, semantic headings on most pages, text-size toggle, dark +
+high-contrast themes, `prefers-reduced-motion` zeroed in tokens, 56px touch
+target token, read-aloud on modules, `aria-live` quiz feedback.
+
+Gaps found:
+- **A-1** Accent/CTA contrast (see C-1).
+- **A-2** Focus ring used `--color-accent` (2.7:1) → could be invisible against
+  light surfaces. Rebuild re-points the ring to `--color-accent-strong`.
+- **A-3** Inline-coloured sections bypass dark mode (C-2): e.g. the
+  scam-of-the-month box stays light-red in dark mode, breaking contrast.
+- **A-4** `for-libraries.html` excluded from the a11y bar, dark mode, and
+  read-aloud entirely (C-3).
+
+---
+
+## 7. Scope decision for v1
+
+The site is large, SEO-rich, and JS-coupled. A destructive full rewrite would
+risk schema, links, and behaviour. v1 therefore:
+
+1. Hardens `tokens.css` to verified WCAG 2.2 AA and adds a CTA-safe accent.
+2. Adds `dcc-core.css` — a token-only refinement layer loaded last.
+3. Rebuilds the three core front-door pages (`index.html`, `resources.html`,
+   `for-libraries.html`) onto tokens, de-inlining the off-token sections.
+4. Adds `AGENTS.md` to govern every future agent run.
+
+Follow-up (tracked for later runs): migrate remaining inline styles on
+`about.html` and module pages; retire page-private palettes; add `dcc-core.css`
+to the global include set.

--- a/css/dcc-core.css
+++ b/css/dcc-core.css
@@ -104,6 +104,7 @@ a.btn-primary:hover,
 .dcc-callout__title {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-2);
   margin: 0 0 var(--space-3);
   font-family: var(--font-heading);

--- a/css/dcc-core.css
+++ b/css/dcc-core.css
@@ -1,0 +1,297 @@
+/* ============================================================================
+   DCC Core — production refinement layer (v1, 2026-06-18)
+   ----------------------------------------------------------------------------
+   Senior-accessible UI rebuild. Token-driven only: every value references a
+   custom property from tokens.css. Loaded LAST so it can harmonise the
+   ad-hoc, off-token sections that made core pages look generic, without
+   touching page content, links, or JavaScript hooks.
+
+   Load order on a page:
+     main.css → tokens.css → tokens-dark.css → fonts.css → components.css
+     → accessibility.css → mobile.css → dcc-core.css   (this file, last)
+
+   Contents:
+     1. Focus + reduced motion safety net
+     2. Accessible primary CTA (fixes white-on-#E8842C 2.7:1 failure)
+     3. .dcc-callout — one component for every coloured info/alert box
+     4. .dcc-card top accents (replaces inline border-top hex)
+     5. Marketing primitives: hero, section, feature grid, steps, CTA band
+     6. Utilities
+   ========================================================================== */
+
+/* --- 1. Focus + motion safety net ---------------------------------------- */
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: var(--radius-sm);
+}
+
+/* Keyboard users must never lose the focus ring behind the sticky header. */
+html { scroll-padding-top: calc(var(--nav-height) + var(--space-4)); }
+
+/* --- 2. Accessible primary CTA ------------------------------------------- */
+/* Legacy .btn-primary used white text on --color-accent (#E8842C = 2.7:1,
+   FAILS). Re-point primary CTAs to the AA-safe --color-accent-strong. */
+.dcc-btn,
+a.dcc-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: var(--tap-target);
+  padding: var(--space-3) var(--space-6);
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-h5);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  text-decoration: none;
+  text-align: center;
+  cursor: pointer;
+  transition: background-color var(--motion-duration-2) var(--motion-ease),
+              border-color var(--motion-duration-2) var(--motion-ease);
+}
+.dcc-btn--primary,
+a.dcc-btn--primary {
+  background: var(--color-accent-strong);
+  color: var(--color-accent-contrast);
+}
+.dcc-btn--primary:hover,
+a.dcc-btn--primary:hover { background: var(--color-accent-hover); color: var(--color-accent-contrast); }
+.dcc-btn--primary:active { background: var(--color-accent-active); }
+
+.dcc-btn--secondary,
+a.dcc-btn--secondary {
+  background: var(--color-surface);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+.dcc-btn--secondary:hover { background: var(--color-primary-light); }
+
+.dcc-btn--on-dark,
+a.dcc-btn--on-dark {
+  background: var(--color-text-inverse);
+  color: var(--color-primary);
+}
+.dcc-btn--on-dark:hover { background: var(--color-surface); }
+
+/* Harmonise existing primary CTAs on pages that load this file. */
+.btn-primary,
+a.btn-primary,
+.email-invite-btn {
+  background-color: var(--color-accent-strong) !important;
+  color: var(--color-accent-contrast) !important;
+}
+.btn-primary:hover,
+a.btn-primary:hover,
+.email-invite-btn:hover { background-color: var(--color-accent-hover) !important; }
+
+/* --- 3. .dcc-callout ----------------------------------------------------- */
+/* One accessible component for every coloured information / alert box.
+   Replaces ad-hoc inline styles like background:#fff3f3;border:3px solid …  */
+.dcc-callout {
+  margin: var(--space-8) 0;
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-left: 6px solid var(--color-primary);
+  border-radius: var(--radius-lg);
+  color: var(--color-text);
+}
+.dcc-callout > :first-child { margin-top: 0; }
+.dcc-callout > :last-child { margin-bottom: 0; }
+.dcc-callout__title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+}
+.dcc-callout p { line-height: var(--line-height-body); }
+
+.dcc-callout--brand   { background: var(--color-surface-primary); border-left-color: var(--color-primary); }
+.dcc-callout--info    { background: var(--color-info-light);      border-left-color: var(--color-info); }
+.dcc-callout--success { background: var(--color-success-light);   border-left-color: var(--color-success); }
+.dcc-callout--success .dcc-callout__title { color: var(--color-success-deep); }
+.dcc-callout--warning { background: var(--color-warning-light);   border-left-color: var(--color-warning); }
+.dcc-callout--warning .dcc-callout__title { color: var(--color-warning-deep); }
+.dcc-callout--danger  { background: var(--color-error-light);     border-left-color: var(--color-error); }
+.dcc-callout--danger  .dcc-callout__title { color: var(--color-error); }
+
+.dcc-callout__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+/* --- 4. Card top accents (replace inline border-top:#hex) ---------------- */
+.dcc-top--brand   { border-top: 4px solid var(--color-primary) !important; }
+.dcc-top--accent  { border-top: 4px solid var(--color-accent) !important; }
+.dcc-top--info    { border-top: 4px solid var(--color-info) !important; }
+.dcc-top--success { border-top: 4px solid var(--color-success-deep) !important; }
+.dcc-top--warning { border-top: 4px solid var(--color-warning-deep) !important; }
+
+/* --- 5. Marketing primitives (used by rebuilt for-libraries.html) -------- */
+.dcc-page { color: var(--color-text); background: var(--color-bg); }
+
+.dcc-shell {
+  width: 100%;
+  max-width: var(--container-max);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
+}
+
+.dcc-section { padding-block: var(--space-16); }
+.dcc-section--tight { padding-block: var(--space-12); }
+.dcc-section--surface { background: var(--color-surface); }
+.dcc-section--brand {
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+}
+.dcc-section--brand h1,
+.dcc-section--brand h2,
+.dcc-section--brand h3,
+.dcc-section--brand p { color: var(--color-text-inverse); }
+
+.dcc-section__lead {
+  max-width: var(--content-max);
+  font-size: var(--font-size-lead);
+  line-height: var(--line-height-lead);
+}
+
+.dcc-eyebrow {
+  display: inline-block;
+  margin-bottom: var(--space-3);
+  padding: var(--space-1) var(--space-4);
+  background: var(--color-surface-alt);
+  color: var(--color-accent-deep);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+.dcc-section--brand .dcc-eyebrow {
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--color-text-inverse);
+}
+
+/* Hero */
+.dcc-hero { padding-block: var(--space-16); background: var(--color-surface-primary); }
+.dcc-hero__grid {
+  display: grid;
+  gap: var(--space-12);
+  align-items: center;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 768px) {
+  .dcc-hero__grid { grid-template-columns: 1.1fr 0.9fr; }
+}
+.dcc-hero h1 {
+  font-size: var(--font-size-h1);
+  line-height: var(--line-height-tight);
+  color: var(--color-primary);
+  margin: 0 0 var(--space-4);
+}
+.dcc-hero__sub {
+  font-size: var(--font-size-lead);
+  line-height: var(--line-height-lead);
+  max-width: 40ch;
+  margin: 0 0 var(--space-6);
+}
+.dcc-hero__actions { display: flex; flex-wrap: wrap; gap: var(--space-4); }
+.dcc-hero__media img {
+  width: 100%;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+}
+
+/* Feature / value grid */
+.dcc-grid {
+  display: grid;
+  gap: var(--space-6);
+  grid-template-columns: 1fr;
+}
+@media (min-width: 600px)  { .dcc-grid--2 { grid-template-columns: repeat(2, 1fr); }
+                             .dcc-grid--3 { grid-template-columns: repeat(2, 1fr); } }
+@media (min-width: 920px)  { .dcc-grid--3 { grid-template-columns: repeat(3, 1fr); } }
+
+.dcc-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-6);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  height: 100%;
+}
+.dcc-section--surface .dcc-card { background: var(--color-bg); }
+.dcc-card__icon {
+  font-size: 2rem;
+  line-height: 1;
+  margin-bottom: var(--space-2);
+}
+.dcc-card h3 {
+  margin: 0;
+  font-size: var(--font-size-h3);
+  color: var(--color-primary);
+}
+.dcc-card p { margin: 0; line-height: var(--line-height-body); }
+
+/* Numbered steps */
+.dcc-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-6);
+  counter-reset: dcc-step;
+}
+.dcc-steps > li {
+  position: relative;
+  padding-left: calc(var(--space-12) + var(--space-2));
+  counter-increment: dcc-step;
+}
+.dcc-steps > li::before {
+  content: counter(dcc-step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--space-12);
+  height: var(--space-12);
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  border-radius: var(--radius-circle);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-bold);
+}
+.dcc-steps h3 { margin: 0 0 var(--space-2); font-size: var(--font-size-h4); color: var(--color-text); }
+.dcc-steps p { margin: 0; }
+
+/* CTA band */
+.dcc-cta-band { text-align: center; }
+.dcc-cta-band h2 { font-size: var(--font-size-h1); margin: 0 0 var(--space-4); }
+.dcc-cta-band p { max-width: 52ch; margin: 0 auto var(--space-6); font-size: var(--font-size-lead); }
+.dcc-cta-band .dcc-hero__actions { justify-content: center; }
+
+/* --- 6. Utilities -------------------------------------------------------- */
+.dcc-center { text-align: center; }
+.dcc-measure { max-width: var(--content-max); }
+.dcc-mt-0 { margin-top: 0; }
+.dcc-stack > * + * { margin-top: var(--space-4); }
+.dcc-sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}

--- a/css/tokens-dark.css
+++ b/css/tokens-dark.css
@@ -28,6 +28,7 @@ html.theme-dark {
   --color-primary-contrast:#1C1915;
 
   --color-accent:          #F5A563; /* lighter burnt orange for dark */
+  --color-accent-strong:   #F5A563; /* on dark, the light orange + dark text already passes AA */
   --color-accent-hover:    #F7B679;
   --color-accent-active:   #FAC790;
   --color-accent-light:    #3A2A1E;
@@ -107,6 +108,7 @@ html.theme-dark {
     --color-primary-contrast:#1C1915;
 
     --color-accent:          #F5A563;
+    --color-accent-strong:   #F5A563;
     --color-accent-hover:    #F7B679;
     --color-accent-active:   #FAC790;
     --color-accent-light:    #3A2A1E;

--- a/css/tokens-high-contrast.css
+++ b/css/tokens-high-contrast.css
@@ -22,6 +22,7 @@ html.theme-high-contrast {
   --color-primary-contrast:#FFFFFF;
 
   --color-accent:          #8A3A00; /* ultra-dark burnt orange, AAA */
+  --color-accent-strong:   #8A3A00;
   --color-accent-hover:    #6B2D00;
   --color-accent-active:   #4D2000;
   --color-accent-light:    #F2F2F2;
@@ -72,6 +73,7 @@ html.theme-high-contrast {
     --color-primary-contrast:#FFFFFF;
 
     --color-accent:          #8A3A00;
+    --color-accent-strong:   #8A3A00;
     --color-accent-light:    #F2F2F2;
 
     --color-text:            #000000;

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,14 +1,32 @@
 /* ============================================================================
-   DCC Design Tokens — Warm Hearth theme (default)
+   DCC Design Tokens — Warm Hearth theme (default)   ·  v2 (2026-06-18)
    ----------------------------------------------------------------------------
    Voted winner (Option A, 65.5%). Kitchen-table warmth, trusted-neighbour
-   tone, zero intimidation. WCAG AA on every token pair.
+   tone, zero intimidation. Tuned for seniors 65+ on tablets/phones, often
+   in dark mode and at high zoom.
 
    All values are CSS custom properties on :root. Components never hard-code
    colours, font sizes, spacing, shadows, or radii — always reference tokens.
    Swap themes by loading tokens-dark.css, tokens-high-contrast.css, or
    tokens-alt.css instead of this file. Structure (bones) lives in
-   components.css; this file is skin only.
+   components.css; production refinements live in dcc-core.css; this file is
+   skin only.
+
+   --------------------------------------------------------------------------
+   VERIFIED WCAG 2.2 AA CONTRAST (computed 2026-06-18, light theme)
+   --------------------------------------------------------------------------
+     text       #1A1A2E on bg      #FAFAF8  → 16.32:1  (AAA)
+     text       #1A1A2E on surface #F5F2ED  → 15.28:1  (AAA)
+     text-light #50505F on bg      #FAFAF8  →  7.57:1  (AAA)
+     primary    #2A7B6F on white            →  5.05:1  (AA, AAA large)
+     white      on primary #2A7B6F          →  5.05:1  (AA)
+     accent-strong #A85410 / white          →  5.33:1  (AA)  ← use for buttons
+     accent     #E8842C / white             →  2.70:1  (FAILS as text) ← decorative only
+     accent-deep #8A450C on #FFF0E0          →  6.40:1  (AA+)
+     error      #B71C1C on white            →  6.57:1  (AA+)
+     warning-deep #7A5800 on #FFF8E1         →  6.13:1  (AA+)
+     success-deep #1B5E20 on #E8F5E9         →  7.00:1  (AAA)
+   Re-run /AGENTS.md → "Checking contrast" after changing any colour token.
    ========================================================================== */
 
 :root {
@@ -27,12 +45,13 @@
   --color-primary-light:   #E8F5F0;
   --color-primary-contrast:#FFFFFF;
 
-  --color-accent:          #E8842C; /* burnt orange — CTAs, focus */
-  --color-accent-hover:    #CF7324;
-  --color-accent-active:   #B5631D;
+  --color-accent:          #E8842C; /* burnt orange — DECORATIVE ONLY: progress fills, large icons, borders, hero flourishes. Do NOT use as a text/button background (white-on-#E8842C is only 2.7:1 — fails WCAG). */
+  --color-accent-strong:   #A85410; /* burnt orange, AA-safe — white text on this is 5.33:1. Use for ALL primary button/CTA backgrounds and the focus ring. */
+  --color-accent-hover:    #8F470D; /* darker accent-strong for hover (white text 6.9:1) */
+  --color-accent-active:   #7A3D0B; /* pressed */
   --color-accent-light:    #FFF0E0;
   --color-accent-contrast: #FFFFFF;
-  --color-accent-deep:     #8A450C; /* text-on-accent-light — 7:1+ on #FFF0E0 (AAA) */
+  --color-accent-deep:     #8A450C; /* text-on-accent-light — 6.4:1 on #FFF0E0 (AA+). Use for orange text on light fills. */
 
   /* --- Colour: text -------------------------------------------------------- */
   --color-text:            #1A1A2E; /* softer near-black (Theme B — less brownish, higher contrast) */
@@ -121,7 +140,7 @@
   --shadow-sm:  0 1px 4px rgba(26, 26, 46, 0.06);
   --shadow-md:  0 2px 8px rgba(26, 26, 46, 0.08);   /* Theme B card elevation */
   --shadow-lg:  0 4px 20px rgba(26, 26, 46, 0.12);
-  --shadow-focus: 0 0 0 3px var(--color-accent);
+  --shadow-focus: 0 0 0 3px var(--color-accent-strong); /* AA-safe focus ring (3:1+ vs light bg) */
 
   /* --- Motion (honour prefers-reduced-motion — see below) ----------------- */
   --motion-ease:       cubic-bezier(0.22, 0.61, 0.36, 1);
@@ -143,11 +162,15 @@
   --z-tooltip: 300;
   --z-overlay: 400;
 
-  /* --- Focus ring --------------------------------------------------------- */
-  --focus-ring-color:   var(--color-accent);
+  /* --- Focus ring (WCAG 2.2 SC 2.4.13 — 3:1+ contrast vs adjacent) -------- */
+  --focus-ring-color:   var(--color-accent-strong); /* #A85410 — 5.33:1 vs white, passes non-text contrast */
   --focus-ring-width:   3px;
   --focus-ring-offset:  2px;
   --focus-ring:         var(--focus-ring-width) solid var(--focus-ring-color);
+
+  /* --- Lead paragraph + reading rhythm ------------------------------------ */
+  --font-size-lead:     clamp(20px, 1.4vw + 16px, 24px);
+  --line-height-lead:   1.6;
 
   /* --- Touch targets ------------------------------------------------------ */
   --tap-target-min:     44px;   /* WCAG 2.5.5 floor */

--- a/for-libraries.html
+++ b/for-libraries.html
@@ -1,724 +1,254 @@
 <!DOCTYPE html>
-<html lang="en-CA">
+<html lang="en-CA" data-font-size="medium">
 <head>
   <meta charset="UTF-8">
+  <script>(function(){var t=localStorage.getItem('dc-theme');if(!t){t=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}document.documentElement.setAttribute('data-theme',t);})();</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light dark">
-  <meta name="description" content="Digital Confidence Centre — a free, bilingual AI literacy platform for libraries, settlement agencies, and community organisations. 31 self-paced modules. No installation. WCAG 2.1 AA.">
+  <meta name="description" content="Digital Confidence Centre — a free, bilingual AI literacy platform for libraries, settlement agencies, and community organisations. 31 self-paced modules. No installation. WCAG 2.2 AA.">
   <meta property="og:title" content="Digital Confidence Centre — For Libraries & Community Organisations">
   <meta property="og:description" content="AI literacy your community can actually use. 31 free bilingual modules for seniors and newcomers. No installation, no login, no per-seat fees.">
   <meta property="og:type" content="website">
   <meta property="og:locale" content="en_CA">
   <meta property="og:image" content="https://twobirds-kramerica.github.io/digital-confidence/images/senior-woman-ipad.jpg">
-  <title>Digital Confidence Centre — For Libraries & Community Organisations</title>
+  <link rel="canonical" href="https://twobirds-kramerica.github.io/digital-confidence/for-libraries.html">
+  <title>Digital Confidence Centre — For Libraries &amp; Community Organisations</title>
+
+  <link rel="stylesheet" href="css/main.css">
+  <link rel="stylesheet" href="css/tokens.css">
+  <link rel="stylesheet" href="css/tokens-dark.css">
+  <link rel="stylesheet" href="css/tokens-high-contrast.css">
+  <link rel="stylesheet" href="css/fonts.css">
+  <link rel="stylesheet" href="css/components.css">
+  <link rel="stylesheet" href="css/accessibility.css">
+  <link rel="stylesheet" href="css/mobile.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
+
   <style>
-    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    /* Page-specific, token-driven only (no hardcoded hex/px). */
+    .lib-bar {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: var(--space-4);
+      padding: var(--space-3) var(--space-6);
+      background: var(--color-primary);
+      color: var(--color-text-inverse);
+    }
+    .lib-bar a { color: var(--color-text-inverse); }
+    .lib-bar__brand { display: flex; flex-direction: column; font-family: var(--font-heading); font-weight: var(--font-weight-bold); text-decoration: none; }
+    .lib-bar__label { font-size: var(--font-size-caption); font-weight: var(--font-weight-semibold); letter-spacing: var(--letter-spacing-wide); text-transform: uppercase; opacity: 0.85; }
 
-    :root {
-      --navy:        #1A2744;
-      --navy-dark:   #101B35;
-      --blue:        #1D4ED8;
-      --blue-hover:  #1E40AF;
-      --slate-900:   #1E293B;
-      --slate-600:   #475569;
-      --slate-400:   #94A3B8;
-      --slate-200:   #E2E8F0;
-      --slate-100:   #F1F5F9;
-      --white:       #FFFFFF;
-      --green:       #16A34A;
-      --green-light: #DCFCE7;
+    .lib-stats {
+      display: grid; gap: var(--space-4);
+      grid-template-columns: repeat(2, 1fr);
+      margin-top: var(--space-8);
     }
+    @media (min-width: 720px) { .lib-stats { grid-template-columns: repeat(5, 1fr); } }
+    .lib-stat {
+      padding: var(--space-6) var(--space-4); text-align: center;
+      background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-lg);
+    }
+    .lib-stat__num { display: block; font-family: var(--font-heading); font-size: var(--font-size-h1); font-weight: var(--font-weight-bold); color: var(--color-primary); line-height: 1; margin-bottom: var(--space-2); }
+    .lib-stat__label { font-size: var(--font-size-caption); font-weight: var(--font-weight-semibold); color: var(--color-text-light); text-transform: uppercase; letter-spacing: var(--letter-spacing-wide); }
 
-    body {
-      font-family: -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-      color: var(--slate-900);
-      background: var(--white);
-      line-height: 1.6;
-      font-size: 16px;
-    }
+    .lib-modules { display: grid; gap: var(--space-3); grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); margin-top: var(--space-6); list-style: none; padding: 0; }
+    .lib-modules li { padding: var(--space-3) var(--space-4); background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-weight: var(--font-weight-semibold); }
+    .lib-modules .lib-module__num { display: block; font-size: var(--font-size-caption); font-weight: var(--font-weight-bold); color: var(--color-accent-deep); text-transform: uppercase; letter-spacing: var(--letter-spacing-wide); margin-bottom: var(--space-1); }
 
-    a { color: var(--blue); }
-    a:hover { color: var(--blue-hover); }
+    .lib-pricing { display: grid; gap: var(--space-6); grid-template-columns: 1fr; margin-top: var(--space-6); }
+    @media (min-width: 820px) { .lib-pricing { grid-template-columns: repeat(3, 1fr); } }
+    .lib-price { display: flex; flex-direction: column; padding: var(--space-8) var(--space-6); background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
+    .lib-price--featured { background: var(--color-primary); color: var(--color-text-inverse); border-color: var(--color-primary); }
+    .lib-price--featured h3, .lib-price--featured .lib-price__amount, .lib-price--featured .lib-price__tier, .lib-price--featured li { color: var(--color-text-inverse); }
+    .lib-price__tier { font-size: var(--font-size-caption); font-weight: var(--font-weight-bold); letter-spacing: var(--letter-spacing-wide); text-transform: uppercase; color: var(--color-accent-deep); margin-bottom: var(--space-3); }
+    .lib-price__amount { font-family: var(--font-heading); font-size: var(--font-size-h1); font-weight: var(--font-weight-bold); color: var(--color-primary); line-height: 1; }
+    .lib-price__period { color: var(--color-text-light); margin-bottom: var(--space-4); }
+    .lib-price--featured .lib-price__period { color: var(--color-text-inverse); opacity: 0.85; }
+    .lib-price ul { list-style: none; padding: 0; margin: var(--space-4) 0 0; display: grid; gap: var(--space-2); }
+    .lib-price li { padding-left: var(--space-6); position: relative; }
+    .lib-price li::before { content: "✓"; position: absolute; left: 0; font-weight: var(--font-weight-bold); }
 
-    /* ---- Skip link ---- */
-    .skip-link {
-      position: absolute;
-      top: -40px;
-      left: 0;
-      background: var(--navy);
-      color: var(--white);
-      padding: 8px 16px;
-      font-size: 14px;
-      z-index: 999;
-      transition: top 0.2s;
-    }
-    .skip-link:focus { top: 0; }
+    .lib-founding { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-4); margin-top: var(--space-8); }
+    .lib-founding__badge { background: var(--color-accent-strong); color: var(--color-accent-contrast); padding: var(--space-2) var(--space-4); border-radius: var(--radius-pill); font-family: var(--font-heading); font-weight: var(--font-weight-bold); font-size: var(--font-size-sm); white-space: nowrap; }
 
-    /* ---- Site bar ---- */
-    .site-bar {
-      background: var(--navy);
-      color: var(--white);
-      padding: 14px 24px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 16px;
-    }
-    .site-bar-brand {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      text-decoration: none;
-      color: var(--white);
-      font-weight: 700;
-      font-size: 15px;
-    }
-    .site-bar-brand svg { width: 28px; height: 28px; flex-shrink: 0; }
-    .site-bar-label {
-      font-size: 11px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: rgba(255,255,255,0.65);
-      margin-top: 1px;
-    }
-    .site-bar-cta {
-      background: var(--blue);
-      color: var(--white);
-      text-decoration: none;
-      padding: 9px 18px;
-      font-size: 14px;
-      font-weight: 600;
-      border: none;
-      cursor: pointer;
-      white-space: nowrap;
-      transition: background 0.15s;
-    }
-    .site-bar-cta:hover { background: var(--blue-hover); color: var(--white); }
-
-    /* ---- Hero ---- */
-    .hero {
-      background: var(--navy);
-      color: var(--white);
-      padding: 60px 24px 56px;
-      text-align: center;
-    }
-    .hero-eyebrow {
-      font-size: 12px;
-      font-weight: 700;
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-      color: rgba(255,255,255,0.65);
-      margin-bottom: 18px;
-    }
-    .hero h1 {
-      font-size: clamp(28px, 4vw, 44px);
-      font-weight: 900;
-      line-height: 1.15;
-      max-width: 720px;
-      margin: 0 auto 20px;
-    }
-    .hero-sub {
-      font-size: clamp(16px, 2vw, 20px);
-      color: rgba(255,255,255,0.80);
-      max-width: 560px;
-      margin: 0 auto 32px;
-    }
-    .hero-ctas {
-      display: flex;
-      gap: 14px;
-      justify-content: center;
-      flex-wrap: wrap;
-    }
-    .btn-primary {
-      background: var(--blue);
-      color: var(--white);
-      text-decoration: none;
-      padding: 14px 28px;
-      font-size: 16px;
-      font-weight: 700;
-      border: none;
-      cursor: pointer;
-      display: inline-block;
-      transition: background 0.15s;
-    }
-    .btn-primary:hover { background: var(--blue-hover); color: var(--white); }
-    .btn-outline {
-      background: transparent;
-      color: var(--white);
-      text-decoration: none;
-      padding: 14px 28px;
-      font-size: 16px;
-      font-weight: 600;
-      border: 2px solid rgba(255,255,255,0.5);
-      display: inline-block;
-      transition: border-color 0.15s, background 0.15s;
-    }
-    .btn-outline:hover { border-color: var(--white); background: rgba(255,255,255,0.08); color: var(--white); }
-
-    /* ---- Content layout ---- */
-    .page { max-width: 900px; margin: 0 auto; padding: 0 24px; }
-    .section { padding: 56px 0; border-bottom: 1px solid var(--slate-200); }
-    .section:last-of-type { border-bottom: none; }
-
-    h2 {
-      font-size: clamp(20px, 2.5vw, 26px);
-      font-weight: 800;
-      color: var(--navy);
-      margin-bottom: 8px;
-    }
-    .section-sub {
-      font-size: 16px;
-      color: var(--slate-600);
-      margin-bottom: 32px;
-      max-width: 640px;
-    }
-    h3 {
-      font-size: 17px;
-      font-weight: 700;
-      color: var(--navy);
-      margin-bottom: 6px;
-    }
-    p { margin-bottom: 14px; color: var(--slate-900); }
-
-    /* ---- Alert banner ---- */
-    .alert {
-      background: #FEF9C3;
-      border: 2px solid #CA8A04;
-      padding: 16px 20px;
-      margin-bottom: 32px;
-    }
-    .alert strong { color: #7C5700; }
-    .alert p { color: #5C4200; margin: 0; font-size: 15px; }
-
-    /* ---- Stats row ---- */
-    .stats-row {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-      gap: 1px;
-      background: var(--slate-200);
-      border: 1px solid var(--slate-200);
-      margin: 32px 0;
-    }
-    .stat {
-      background: var(--white);
-      padding: 24px 16px;
-      text-align: center;
-    }
-    .stat-num {
-      font-size: 2rem;
-      font-weight: 900;
-      color: var(--navy);
-      display: block;
-      line-height: 1;
-      margin-bottom: 6px;
-    }
-    .stat-label {
-      font-size: 12px;
-      font-weight: 600;
-      color: var(--slate-600);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-    }
-
-    /* ---- Feature grid ---- */
-    .features-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1px;
-      background: var(--slate-200);
-      border: 1px solid var(--slate-200);
-    }
-    .feature {
-      background: var(--white);
-      padding: 24px;
-    }
-    .feature-icon {
-      font-size: 22px;
-      margin-bottom: 10px;
-      display: block;
-    }
-    .feature h3 { font-size: 15px; margin-bottom: 6px; }
-    .feature p { font-size: 14px; color: var(--slate-600); margin: 0; }
-
-    /* ---- Module preview ---- */
-    .module-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-      gap: 1px;
-      background: var(--slate-200);
-      border: 1px solid var(--slate-200);
-      margin-top: 24px;
-    }
-    .module-item {
-      background: var(--slate-100);
-      padding: 14px 16px;
-      font-size: 14px;
-      color: var(--slate-900);
-    }
-    .module-num {
-      font-size: 11px;
-      font-weight: 700;
-      color: var(--slate-400);
-      display: block;
-      margin-bottom: 3px;
-      letter-spacing: 0.05em;
-    }
-
-    /* ---- Audience cards ---- */
-    .audience-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 16px;
-      margin-top: 24px;
-    }
-    .audience-card {
-      border: 1px solid var(--slate-200);
-      padding: 22px;
-      background: var(--slate-100);
-    }
-    .audience-card h3 { font-size: 15px; margin-bottom: 8px; }
-    .audience-card p { font-size: 13px; color: var(--slate-600); margin: 0; }
-
-    /* ---- Grant box ---- */
-    .grant-box {
-      background: var(--slate-100);
-      border: 1px solid var(--slate-200);
-      border-top: 3px solid var(--navy);
-      padding: 28px;
-    }
-
-    /* ---- Be Connected proof box ---- */
-    .proof-box {
-      background: var(--white);
-      border: 1px solid var(--slate-200);
-      padding: 20px 24px;
-      margin-top: 24px;
-      display: flex;
-      gap: 16px;
-      align-items: flex-start;
-    }
-    .proof-flag {
-      font-size: 22px;
-      flex-shrink: 0;
-      line-height: 1;
-      margin-top: 2px;
-    }
-    .proof-text h4 {
-      font-size: 14px;
-      font-weight: 700;
-      color: var(--navy);
-      margin-bottom: 4px;
-    }
-    .proof-text p {
-      font-size: 14px;
-      color: var(--slate-600);
-      margin: 0;
-    }
-    .proof-text a { color: var(--blue); }
-    .grant-box h3 { font-size: 18px; margin-bottom: 10px; }
-    .grant-box ul { padding-left: 20px; margin-top: 10px; }
-    .grant-box li { font-size: 15px; color: var(--slate-900); margin-bottom: 6px; }
-
-    /* ---- Pricing ---- */
-    .pricing-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1px;
-      background: var(--slate-200);
-      border: 1px solid var(--slate-200);
-      margin-top: 24px;
-    }
-    .price-card {
-      background: var(--white);
-      padding: 28px 24px;
-    }
-    .price-card.featured {
-      background: var(--navy);
-      color: var(--white);
-    }
-    .price-tier {
-      font-size: 11px;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--slate-400);
-      margin-bottom: 10px;
-      display: block;
-    }
-    .price-card.featured .price-tier { color: rgba(255,255,255,0.55); }
-    .price-amount {
-      font-size: 2.2rem;
-      font-weight: 900;
-      color: var(--navy);
-      line-height: 1;
-    }
-    .price-card.featured .price-amount { color: var(--white); }
-    .price-period {
-      font-size: 13px;
-      color: var(--slate-600);
-      margin-bottom: 16px;
-      display: block;
-    }
-    .price-card.featured .price-period { color: rgba(255,255,255,0.65); }
-    .price-scope {
-      font-size: 13px;
-      font-weight: 600;
-      margin-bottom: 16px;
-      color: var(--navy);
-    }
-    .price-card.featured .price-scope { color: rgba(255,255,255,0.85); }
-    .price-features { list-style: none; padding: 0; border-top: 1px solid var(--slate-200); padding-top: 16px; }
-    .price-card.featured .price-features { border-color: rgba(255,255,255,0.2); }
-    .price-features li {
-      font-size: 14px;
-      color: var(--slate-900);
-      padding: 5px 0 5px 20px;
-      position: relative;
-    }
-    .price-card.featured .price-features li { color: rgba(255,255,255,0.9); }
-    .price-features li::before {
-      content: '✓';
-      position: absolute;
-      left: 0;
-      color: var(--green);
-      font-weight: 700;
-    }
-    .price-card.featured .price-features li::before { color: #4ADE80; }
-
-    /* ---- Founding partner banner ---- */
-    .founding-banner {
-      background: var(--navy);
-      color: var(--white);
-      padding: 32px 28px;
-      margin-top: 28px;
-      display: flex;
-      align-items: flex-start;
-      gap: 20px;
-      flex-wrap: wrap;
-    }
-    .founding-badge {
-      background: #FCD34D;
-      color: var(--navy);
-      font-size: 11px;
-      font-weight: 800;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      padding: 4px 10px;
-      white-space: nowrap;
-      flex-shrink: 0;
-    }
-    .founding-text { flex: 1; min-width: 200px; }
-    .founding-text p { color: rgba(255,255,255,0.85); margin: 0; font-size: 15px; }
-    .founding-text strong { color: var(--white); }
-
-    /* ---- FAQ ---- */
-    .faq-list { margin-top: 24px; }
-    .faq-item { border-bottom: 1px solid var(--slate-200); padding: 20px 0; }
-    .faq-item:first-child { border-top: 1px solid var(--slate-200); }
-    .faq-q {
-      font-size: 16px;
-      font-weight: 700;
-      color: var(--navy);
-      margin-bottom: 8px;
-    }
-    .faq-a { font-size: 15px; color: var(--slate-600); margin: 0; }
-
-    /* ---- CTA section ---- */
-    .cta-section {
-      background: var(--navy);
-      color: var(--white);
-      padding: 56px 24px;
-      text-align: center;
-    }
-    .cta-section h2 { color: var(--white); font-size: clamp(22px, 3vw, 30px); margin-bottom: 12px; }
-    .cta-section p { color: rgba(255,255,255,0.75); font-size: 17px; max-width: 480px; margin: 0 auto 28px; }
-    .cta-contact { font-size: 14px; color: rgba(255,255,255,0.55); margin-top: 16px; }
-    .cta-contact a { color: rgba(255,255,255,0.75); }
-
-    /* ---- Footer ---- */
-    .footer {
-      border-top: 3px solid var(--navy);
-      padding: 24px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 16px;
-      flex-wrap: wrap;
-    }
-    .footer p { font-size: 13px; color: var(--slate-400); margin: 0; }
-    .footer a { color: var(--slate-600); font-size: 13px; text-decoration: none; }
-    .footer a:hover { color: var(--navy); }
-
-    /* ---- Responsive ---- */
-    @media (max-width: 600px) {
-      .site-bar { flex-direction: column; align-items: flex-start; gap: 12px; }
-      .hero { padding: 40px 20px 36px; }
-      .page { padding: 0 16px; }
-      .section { padding: 40px 0; }
-      .founding-banner { flex-direction: column; }
-    }
-
-    @media print {
-      .site-bar, .hero-ctas, .cta-section, .footer { display: none; }
-    }
-
-    @media (prefers-color-scheme: dark) {
-      body { background: #0F172A; color: #CBD5E1; }
-
-      /* Headings that use var(--navy) as text colour on light bg */
-      h2 { color: #E2E8F0; }
-      h3 { color: #CBD5E1; }
-      p  { color: #CBD5E1; }
-      a  { color: #60A5FA; }
-      a:hover { color: #93C5FD; }
-
-      /* Secondary / muted text */
-      .section-sub  { color: #94A3B8; }
-      .faq-a        { color: #94A3B8; }
-      .feature p    { color: #94A3B8; }
-      .audience-card p { color: #94A3B8; }
-      .proof-text p { color: #94A3B8; }
-
-      /* Stat numbers use var(--navy) for colour */
-      .stat-num   { color: #93C5FD; }
-      .stat-label { color: #94A3B8; }
-
-      /* Module num */
-      .module-num { color: #64748B; }
-
-      /* Card / section backgrounds */
-      .stat         { background: #1E293B; }
-      .feature      { background: #1E293B; }
-      .module-item  { background: #162032; color: #CBD5E1; }
-      .audience-card { background: #162032; border-color: rgba(255,255,255,0.12); }
-      .grant-box    { background: #162032; border-top-color: #475569;
-                      border-color: rgba(255,255,255,0.12); }
-      .grant-box p  { color: #CBD5E1; }   /* override inline color: var(--slate-600) */
-      .grant-box li { color: #CBD5E1; }
-      .proof-box    { background: #1E293B; border-color: rgba(255,255,255,0.12); }
-      .proof-text h4 { color: #E2E8F0; }
-
-      /* Price cards */
-      .price-card         { background: #1E293B; }
-      .price-tier         { color: #64748B; }
-      .price-amount       { color: #E2E8F0; }
-      .price-period       { color: #94A3B8; }
-      .price-scope        { color: #CBD5E1; }
-      .price-features     { border-top-color: rgba(255,255,255,0.12); }
-      .price-features li  { color: #CBD5E1; }
-
-      /* Grid gaps (1px separator lines between grid cells) */
-      .stats-row, .features-grid, .module-grid, .pricing-grid {
-        background: rgba(255,255,255,0.08);
-      }
-
-      /* Dividers */
-      .section          { border-bottom-color: rgba(255,255,255,0.08); }
-      .faq-item         { border-bottom-color: rgba(255,255,255,0.08); }
-      .faq-item:first-child { border-top-color: rgba(255,255,255,0.08); }
-      .faq-q            { color: #E2E8F0; }
-
-      /* Alert: dark amber variant */
-      .alert          { background: #422006; border-color: #92400E; }
-      .alert strong   { color: #FDE68A; }
-      .alert p        { color: #FCD34D; }
-
-      /* Buttons: keep primary blue, adjust for dark bg readability */
-      .btn-primary        { background: #2563EB; }
-      .btn-primary:hover  { background: #1D4ED8; }
-      .site-bar-cta       { background: #2563EB; }
-      .site-bar-cta:hover { background: #1D4ED8; color: #FFFFFF; }
-
-      /* Footer */
-      .footer   { border-top-color: rgba(255,255,255,0.12); }
-      .footer p { color: #64748B; }
-      .footer a { color: #94A3B8; }
-      .footer a:hover { color: #E2E8F0; }
-    }
+    .lib-faq { display: grid; gap: var(--space-4); margin-top: var(--space-6); }
+    .lib-faq__item { padding: var(--space-6); background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
+    .lib-faq__q { margin: 0 0 var(--space-2); font-family: var(--font-heading); font-size: var(--font-size-h4); font-weight: var(--font-weight-bold); color: var(--color-text); }
+    .lib-faq__a { margin: 0; }
   </style>
 </head>
-<body>
+<body class="dcc-page">
 
   <a href="#main" class="skip-link">Skip to main content</a>
 
+  <!-- Accessibility controls (shared across DCC) -->
+  <div class="accessibility-bar" role="toolbar" aria-label="Accessibility controls">
+    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false" style="font-size:0.8rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true" style="font-size:1rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false" style="font-size:1.2rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false" style="font-size:1.4rem">A</button>
+    <button class="a11y-btn theme-toggle-btn" aria-label="Switch to dark mode">🌓</button>
+  </div>
+
   <!-- Site bar -->
-  <header class="site-bar" role="banner">
-    <a href="index.html" class="site-bar-brand" aria-label="Digital Confidence Centre — home">
-      <svg viewBox="0 0 32 32" aria-hidden="true" fill="none">
-        <circle cx="16" cy="16" r="15" fill="#1D4ED8"/>
-        <path d="M9 16c0-3.87 3.13-7 7-7s7 3.13 7 7" stroke="white" stroke-width="2.5" stroke-linecap="square"/>
-        <circle cx="16" cy="22" r="3" fill="white"/>
-      </svg>
-      <div>
-        <div>Digital Confidence Centre</div>
-        <div class="site-bar-label">For Libraries &amp; Organisations</div>
-      </div>
+  <header class="lib-bar" role="banner">
+    <a href="index.html" class="lib-bar__brand" aria-label="Digital Confidence Centre — home">
+      <span>Digital Confidence Centre</span>
+      <span class="lib-bar__label">For Libraries &amp; Organisations</span>
     </a>
-    <a href="https://calendly.com/twobirdsinnovation/30min" class="site-bar-cta" target="_blank" rel="noopener noreferrer">
-      Book a 30-minute demo
-    </a>
+    <a href="https://calendly.com/twobirdsinnovation/30min" class="dcc-btn dcc-btn--on-dark" target="_blank" rel="noopener noreferrer">Book a 30-minute demo</a>
   </header>
 
   <!-- Hero -->
-  <section class="hero" aria-labelledby="hero-heading">
-    <div class="hero-eyebrow">For libraries · settlement agencies · community organisations</div>
-    <h1 id="hero-heading">AI literacy your community<br>can actually use.</h1>
-    <p class="hero-sub">31 free, bilingual modules covering online safety, banking, AI basics, and digital independence. No installation. No login. No per-seat fees.</p>
-    <div class="hero-ctas">
-      <a href="https://calendly.com/twobirdsinnovation/30min" class="btn-primary" target="_blank" rel="noopener noreferrer">Book a demo</a>
-      <a href="facilitator-guide.html" class="btn-outline" target="_blank" rel="noopener noreferrer">Download facilitator guide</a>
+  <section class="dcc-section dcc-section--brand dcc-cta-band" aria-labelledby="hero-heading">
+    <div class="dcc-shell">
+      <span class="dcc-eyebrow">For libraries · settlement agencies · community organisations</span>
+      <h1 id="hero-heading">AI literacy your community can actually use</h1>
+      <p>31 free, bilingual modules covering online safety, banking, AI basics, and digital independence. No installation. No login. No per-seat fees.</p>
+      <div class="dcc-hero__actions">
+        <a href="https://calendly.com/twobirdsinnovation/30min" class="dcc-btn dcc-btn--on-dark" target="_blank" rel="noopener noreferrer">Book a demo</a>
+        <a href="facilitator-guide.html" class="dcc-btn dcc-btn--secondary" target="_blank" rel="noopener noreferrer">Download facilitator guide</a>
+      </div>
     </div>
   </section>
 
   <main id="main">
-    <div class="page">
 
-      <!-- Problem -->
-      <section class="section" aria-labelledby="problem-heading">
+    <!-- Problem -->
+    <section class="dcc-section" aria-labelledby="problem-heading">
+      <div class="dcc-shell">
         <h2 id="problem-heading">The DLEP gap is real — and your patrons are asking for help</h2>
-        <div class="section-sub">The Digital Literacy Exchange Program ended in March 2025. Thousands of community members who relied on funded AI literacy sessions are still looking for somewhere to turn.</div>
+        <p class="dcc-section__lead">The Digital Literacy Exchange Program ended in March 2025. Thousands of community members who relied on funded AI literacy sessions are still looking for somewhere to turn.</p>
 
-        <div class="alert" role="note">
+        <div class="dcc-callout dcc-callout--warning" role="note">
           <p><strong>The funding gap:</strong> DLEP supported local digital literacy delivery across Canada for years. Without a replacement, libraries and settlement agencies are fielding AI and technology questions they don't yet have curriculum for. Digital Confidence Centre fills that gap — free for learners, structured for facilitators, ready to deploy today.</p>
         </div>
 
-        <div class="stats-row" role="list" aria-label="Platform statistics">
-          <div class="stat" role="listitem">
-            <span class="stat-num">31</span>
-            <span class="stat-label">Learning modules</span>
-          </div>
-          <div class="stat" role="listitem">
-            <span class="stat-num">2</span>
-            <span class="stat-label">Languages (EN / FR)</span>
-          </div>
-          <div class="stat" role="listitem">
-            <span class="stat-num">AA</span>
-            <span class="stat-label">WCAG 2.1 accessibility</span>
-          </div>
-          <div class="stat" role="listitem">
-            <span class="stat-num">~25</span>
-            <span class="stat-label">Minutes per module</span>
-          </div>
-          <div class="stat" role="listitem">
-            <span class="stat-num">$0</span>
-            <span class="stat-label">Patron cost</span>
-          </div>
-        </div>
+        <ul class="lib-stats" aria-label="Platform statistics">
+          <li class="lib-stat"><span class="lib-stat__num">31</span><span class="lib-stat__label">Learning modules</span></li>
+          <li class="lib-stat"><span class="lib-stat__num">2</span><span class="lib-stat__label">Languages (EN / FR)</span></li>
+          <li class="lib-stat"><span class="lib-stat__num">AA</span><span class="lib-stat__label">WCAG 2.2 accessibility</span></li>
+          <li class="lib-stat"><span class="lib-stat__num">~25</span><span class="lib-stat__label">Minutes per module</span></li>
+          <li class="lib-stat"><span class="lib-stat__num">$0</span><span class="lib-stat__label">Patron cost</span></li>
+        </ul>
 
-        <div class="proof-box">
-          <span class="proof-flag" aria-hidden="true">🇦🇺</span>
-          <div class="proof-text">
-            <h4>This model is internationally proven</h4>
-            <p><a href="https://beconnected.esafety.gov.au/" target="_blank" rel="noopener noreferrer">Be Connected</a> — Australia's national digital literacy program for seniors — reaches over 1,200 library and community organisation partners using the same model: free, self-paced modules delivered through trusted community venues. DCC brings the same approach to Canadian libraries and settlement agencies, using locally relevant content and bilingual (EN/FR) delivery.</p>
-          </div>
+        <div class="dcc-callout dcc-callout--brand">
+          <p class="dcc-callout__title"><span aria-hidden="true">🇦🇺</span> This model is internationally proven</p>
+          <p><a href="https://beconnected.esafety.gov.au/" target="_blank" rel="noopener noreferrer">Be Connected</a> — Australia's national digital literacy program for seniors — reaches over 1,200 library and community organisation partners using the same model: free, self-paced modules delivered through trusted community venues. DCC brings the same approach to Canadian libraries and settlement agencies, using locally relevant content and bilingual (EN/FR) delivery.</p>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <!-- Features -->
-      <section class="section" aria-labelledby="features-heading">
+    <!-- Features -->
+    <section class="dcc-section dcc-section--surface" aria-labelledby="features-heading">
+      <div class="dcc-shell">
         <h2 id="features-heading">Built for facilitated delivery</h2>
-        <div class="section-sub">Every design decision reduces facilitator prep time and works for the patrons least comfortable with technology.</div>
+        <p class="dcc-section__lead">Every design decision reduces facilitator prep time and works for the patrons least comfortable with technology.</p>
 
-        <div class="features-grid" role="list">
-          <div class="feature" role="listitem">
-            <span class="feature-icon" aria-hidden="true">🖥️</span>
+        <div class="dcc-grid dcc-grid--3" role="list">
+          <div class="dcc-card" role="listitem">
+            <span class="dcc-card__icon" aria-hidden="true">🖥️</span>
             <h3>No installation required</h3>
             <p>Runs in any browser on any device. No app store, no accounts, no admin access needed.</p>
           </div>
-          <div class="feature" role="listitem">
-            <span class="feature-icon" aria-hidden="true">🔐</span>
+          <div class="dcc-card" role="listitem">
+            <span class="dcc-card__icon" aria-hidden="true">🔐</span>
             <h3>No patron login</h3>
             <p>Learners access modules directly — no email, no password, no personal data collected.</p>
           </div>
-          <div class="feature" role="listitem">
-            <span class="feature-icon" aria-hidden="true">🇫🇷</span>
+          <div class="dcc-card" role="listitem">
+            <span class="dcc-card__icon" aria-hidden="true">🇫🇷</span>
             <h3>Bilingual (EN / FR)</h3>
             <p>Full French curriculum included. Toggle available on every page — no separate URL.</p>
           </div>
-          <div class="feature" role="listitem">
-            <span class="feature-icon" aria-hidden="true">♿</span>
-            <h3>WCAG 2.1 AA compliant</h3>
-            <p>Designed for seniors: 18px+ base font, 44px touch targets, screen reader support, high-contrast mode.</p>
+          <div class="dcc-card" role="listitem">
+            <span class="dcc-card__icon" aria-hidden="true">♿</span>
+            <h3>WCAG 2.2 AA compliant</h3>
+            <p>Designed for seniors: 19px base font, 56px touch targets, screen reader support, high-contrast mode.</p>
           </div>
-          <div class="feature" role="listitem">
-            <span class="feature-icon" aria-hidden="true">📱</span>
+          <div class="dcc-card" role="listitem">
+            <span class="dcc-card__icon" aria-hidden="true">📱</span>
             <h3>Works on any device</h3>
             <p>Tablet, phone, desktop. Tested on Android Chrome and iOS Safari. No download required.</p>
           </div>
-          <div class="feature" role="listitem">
-            <span class="feature-icon" aria-hidden="true">🖨️</span>
+          <div class="dcc-card" role="listitem">
+            <span class="dcc-card__icon" aria-hidden="true">🖨️</span>
             <h3>Print centre included</h3>
             <p>Large-print handouts and step-by-step guides for every module — ready for group sessions.</p>
           </div>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <!-- Modules -->
-      <section class="section" aria-labelledby="modules-heading">
+    <!-- Modules -->
+    <section class="dcc-section" aria-labelledby="modules-heading">
+      <div class="dcc-shell">
         <h2 id="modules-heading">What patrons learn</h2>
-        <div class="section-sub">Topics designed around real patron questions — not technology jargon.</div>
+        <p class="dcc-section__lead">Topics designed around real patron questions — not technology jargon.</p>
 
-        <div class="module-grid" role="list" aria-label="Module list">
-          <div class="module-item" role="listitem"><span class="module-num">Module 1</span>Your First Smartphone</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 2</span>Online Safety Basics</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 3</span>Passwords &amp; Accounts</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 4</span>App Store Safety</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 5</span>Email &amp; Messages</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 6</span>Online Banking</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 7</span>Photos &amp; Memories</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 8</span>Staying Connected</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 9</span>Understanding AI</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 10</span>Grocery &amp; Delivery Apps</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 11</span>Ride-Sharing Apps</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 12</span>Getting Help Online</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 13</span>Social Media Safety</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 14</span>Smart Home Devices</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 15</span>Telehealth &amp; Video Calls</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 16</span>Travel Safety Online</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 17</span>AI Research Tools</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 18</span>Long-Distance Connection</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 19</span>Digital Legacy</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 20</span>Internet Plans Explained</div>
-          <div class="module-item" role="listitem"><span class="module-num">Module 21</span>Mobile Plans Explained</div>
-          <div class="module-item" role="listitem"><span class="module-num">Bonus</span>Visual AI — Show Me! Guide</div>
-          <div class="module-item" role="listitem"><span class="module-num">Bonus</span>AI Literacy for Adults</div>
-          <div class="module-item" role="listitem"><span class="module-num">Bonus</span>Scam Simulator (interactive)</div>
-        </div>
-      </section>
+        <ul class="lib-modules" aria-label="Module list">
+          <li><span class="lib-module__num">Module 1</span>Your First Smartphone</li>
+          <li><span class="lib-module__num">Module 2</span>Online Safety Basics</li>
+          <li><span class="lib-module__num">Module 3</span>Passwords &amp; Accounts</li>
+          <li><span class="lib-module__num">Module 4</span>App Store Safety</li>
+          <li><span class="lib-module__num">Module 5</span>Email &amp; Messages</li>
+          <li><span class="lib-module__num">Module 6</span>Online Banking</li>
+          <li><span class="lib-module__num">Module 7</span>Photos &amp; Memories</li>
+          <li><span class="lib-module__num">Module 8</span>Staying Connected</li>
+          <li><span class="lib-module__num">Module 9</span>Understanding AI</li>
+          <li><span class="lib-module__num">Module 10</span>Grocery &amp; Delivery Apps</li>
+          <li><span class="lib-module__num">Module 11</span>Ride-Sharing Apps</li>
+          <li><span class="lib-module__num">Module 12</span>Getting Help Online</li>
+          <li><span class="lib-module__num">Module 13</span>Social Media Safety</li>
+          <li><span class="lib-module__num">Module 14</span>Smart Home Devices</li>
+          <li><span class="lib-module__num">Module 15</span>Telehealth &amp; Video Calls</li>
+          <li><span class="lib-module__num">Module 16</span>Travel Safety Online</li>
+          <li><span class="lib-module__num">Module 17</span>AI Research Tools</li>
+          <li><span class="lib-module__num">Module 18</span>Long-Distance Connection</li>
+          <li><span class="lib-module__num">Module 19</span>Digital Legacy</li>
+          <li><span class="lib-module__num">Module 20</span>Internet Plans Explained</li>
+          <li><span class="lib-module__num">Module 21</span>Mobile Plans Explained</li>
+          <li><span class="lib-module__num">Bonus</span>Visual AI — Show Me! Guide</li>
+          <li><span class="lib-module__num">Bonus</span>AI Literacy for Adults</li>
+          <li><span class="lib-module__num">Bonus</span>Scam Simulator (interactive)</li>
+        </ul>
+      </div>
+    </section>
 
-      <!-- Who it's for -->
-      <section class="section" aria-labelledby="audience-heading">
+    <!-- Who it's for -->
+    <section class="dcc-section dcc-section--surface" aria-labelledby="audience-heading">
+      <div class="dcc-shell">
         <h2 id="audience-heading">Who we work with</h2>
-        <div class="section-sub">Any organisation providing digital support to seniors, newcomers, or low-digital-confidence adults.</div>
+        <p class="dcc-section__lead">Any organisation providing digital support to seniors, newcomers, or low-digital-confidence adults.</p>
 
-        <div class="audience-grid">
-          <div class="audience-card">
+        <div class="dcc-grid dcc-grid--2">
+          <div class="dcc-card">
             <h3>Public Libraries</h3>
             <p>Add structured AI literacy to your existing digital help desk or technology programs. No new infrastructure.</p>
           </div>
-          <div class="audience-card">
+          <div class="dcc-card">
             <h3>Settlement Agencies</h3>
             <p>Digital integration is the barrier for most newcomer clients. DCC gives them a safe, bilingual path forward.</p>
           </div>
-          <div class="audience-card">
+          <div class="dcc-card">
             <h3>Long-Term Care</h3>
             <p>Residents and family members learning to video-call, bank online, and stay connected independently.</p>
           </div>
-          <div class="audience-card">
+          <div class="dcc-card">
             <h3>Community Colleges</h3>
             <p>Supplement continuing education programs or staff development with a structured, free digital literacy track.</p>
           </div>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <!-- NHSP Grant -->
-      <section class="section" aria-labelledby="nhsp-heading">
+    <!-- NHSP Grant -->
+    <section class="dcc-section" aria-labelledby="nhsp-heading">
+      <div class="dcc-shell">
         <h2 id="nhsp-heading">Federal grant eligible: New Horizons for Seniors Program</h2>
-        <div class="section-sub">DCC is designed to fit inside an NHSP project application as the AI literacy delivery component.</div>
+        <p class="dcc-section__lead">DCC is designed to fit inside an NHSP project application as the AI literacy delivery component.</p>
 
-        <div class="grant-box" role="note" aria-label="NHSP grant information">
-          <h3>How DCC fits an NHSP application</h3>
+        <div class="dcc-callout dcc-callout--brand" role="note" aria-label="NHSP grant information">
+          <p class="dcc-callout__title">How DCC fits an NHSP application</p>
           <p>The New Horizons for Seniors Program (Employment and Social Development Canada) funds projects that promote the well-being and social participation of seniors. AI literacy and digital independence are a clear fit.</p>
           <ul>
             <li>DCC provides a completed, bilingual curriculum — no curriculum development cost in your budget</li>
@@ -726,31 +256,26 @@
             <li>Measurable outcome: number of participants completing modules</li>
             <li>Community tier includes NHSP co-application support from Two Birds Innovation</li>
           </ul>
-          <p style="margin-top: 14px; font-size: 14px; color: var(--slate-600);">
-            Community tier partners receive help scoping their NHSP application. <a href="https://calendly.com/twobirdsinnovation/30min" target="_blank" rel="noopener noreferrer">Book a call</a> to discuss eligibility before the next intake opens.
-          </p>
-          <p style="margin-top: 10px; font-size: 14px; color: var(--slate-600);">
-            <strong>Grant application guide:</strong> <a href="institutional.html">Full NHSP application guide</a> — ready-to-use project language, budget templates, measurable outcome targets, and partnership letter guidance.
-          </p>
-          <p style="margin-top: 10px; font-size: 14px; color: var(--slate-600);">
-            <strong>International precedent:</strong> Australia's <a href="https://beconnected.esafety.gov.au/" target="_blank" rel="noopener noreferrer">Be Connected</a> program demonstrates that library-delivered digital literacy is a proven, fundable model — DCC brings this approach to the Canadian context with bilingual curriculum and NHSP-compatible project framing.
-          </p>
+          <p>Community tier partners receive help scoping their NHSP application. <a href="https://calendly.com/twobirdsinnovation/30min" target="_blank" rel="noopener noreferrer">Book a call</a> to discuss eligibility before the next intake opens.</p>
+          <p><strong>Grant application guide:</strong> <a href="institutional.html">Full NHSP application guide</a> — ready-to-use project language, budget templates, measurable outcome targets, and partnership letter guidance.</p>
+          <p><strong>International precedent:</strong> Australia's <a href="https://beconnected.esafety.gov.au/" target="_blank" rel="noopener noreferrer">Be Connected</a> program demonstrates that library-delivered digital literacy is a proven, fundable model — DCC brings this approach to the Canadian context with bilingual curriculum and NHSP-compatible project framing.</p>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <!-- Pricing -->
-      <section class="section" aria-labelledby="pricing-heading">
+    <!-- Pricing -->
+    <section class="dcc-section dcc-section--surface" aria-labelledby="pricing-heading">
+      <div class="dcc-shell">
         <h2 id="pricing-heading">Institutional pricing</h2>
-        <div class="section-sub">The platform is free for learners. Fees cover partner support, content updates, and custom branding for your organisation.</div>
+        <p class="dcc-section__lead">The platform is free for learners. Fees cover partner support, content updates, and custom branding for your organisation.</p>
 
-        <div class="pricing-grid" role="list" aria-label="Pricing tiers">
+        <div class="lib-pricing" role="list" aria-label="Pricing tiers">
 
-          <div class="price-card" role="listitem">
-            <span class="price-tier">Starter</span>
-            <div class="price-amount">CA$500</div>
-            <span class="price-period">per year</span>
-            <p class="price-scope">Up to 3 branches</p>
-            <ul class="price-features">
+          <div class="lib-price" role="listitem">
+            <span class="lib-price__tier">Starter</span>
+            <div class="lib-price__amount">CA$500</div>
+            <span class="lib-price__period">per year · up to 3 branches</span>
+            <ul>
               <li>Full 31-module curriculum</li>
               <li>Bi-annual check-in call</li>
               <li>Usage stats report</li>
@@ -758,12 +283,11 @@
             </ul>
           </div>
 
-          <div class="price-card featured" role="listitem" aria-label="Standard tier (most popular)">
-            <span class="price-tier">Standard — Most Popular</span>
-            <div class="price-amount">CA$1,000</div>
-            <span class="price-period">per year</span>
-            <p class="price-scope">Unlimited branches</p>
-            <ul class="price-features">
+          <div class="lib-price lib-price--featured" role="listitem" aria-label="Standard tier (most popular)">
+            <span class="lib-price__tier">Standard — Most Popular</span>
+            <div class="lib-price__amount">CA$1,000</div>
+            <span class="lib-price__period">per year · unlimited branches</span>
+            <ul>
               <li>Full 31-module curriculum</li>
               <li>Quarterly review call</li>
               <li>Priority content updates</li>
@@ -772,12 +296,11 @@
             </ul>
           </div>
 
-          <div class="price-card" role="listitem">
-            <span class="price-tier">Community</span>
-            <div class="price-amount">CA$2,000</div>
-            <span class="price-period">per year</span>
-            <p class="price-scope">Unlimited branches</p>
-            <ul class="price-features">
+          <div class="lib-price" role="listitem">
+            <span class="lib-price__tier">Community</span>
+            <div class="lib-price__amount">CA$2,000</div>
+            <span class="lib-price__period">per year · unlimited branches</span>
+            <ul>
               <li>Full 31-module curriculum</li>
               <li>Custom branding (your logo)</li>
               <li>NHSP co-application support</li>
@@ -790,71 +313,86 @@
         </div>
 
         <!-- Founding partner offer -->
-        <div class="founding-banner" role="note" aria-label="Founding partner offer">
-          <span class="founding-badge">3 spots available</span>
-          <div class="founding-text">
-            <h3 style="color: white; margin-bottom: 6px;">Founding Partner Rate</h3>
-            <p>The first three libraries or organisations to partner pay the <strong>Starter rate (CA$500/yr)</strong> regardless of which tier they choose — for all of Year 1. Founding Partners also receive direct input on the content roadmap. <a href="https://calendly.com/twobirdsinnovation/30min" style="color: #93C5FD;" target="_blank" rel="noopener noreferrer">Book to claim your spot.</a></p>
+        <div class="dcc-callout dcc-callout--success lib-founding" role="note" aria-label="Founding partner offer">
+          <span class="lib-founding__badge">3 spots available</span>
+          <div>
+            <p class="dcc-callout__title">Founding Partner Rate</p>
+            <p>The first three libraries or organisations to partner pay the <strong>Starter rate (CA$500/yr)</strong> regardless of which tier they choose — for all of Year 1. Founding Partners also receive direct input on the content roadmap. <a href="https://calendly.com/twobirdsinnovation/30min" target="_blank" rel="noopener noreferrer">Book to claim your spot.</a></p>
           </div>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <!-- FAQ -->
-      <section class="section" aria-labelledby="faq-heading">
+    <!-- FAQ -->
+    <section class="dcc-section" aria-labelledby="faq-heading">
+      <div class="dcc-shell">
         <h2 id="faq-heading">Common questions</h2>
 
-        <div class="faq-list">
-          <div class="faq-item">
-            <div class="faq-q">Is there any cost for our patrons or participants?</div>
-            <p class="faq-a">No. The platform is free for every learner. Institutional fees cover partner support, custom branding, and content updates — not per-seat access.</p>
+        <div class="lib-faq">
+          <div class="lib-faq__item">
+            <p class="lib-faq__q">Is there any cost for our patrons or participants?</p>
+            <p class="lib-faq__a">No. The platform is free for every learner. Institutional fees cover partner support, custom branding, and content updates — not per-seat access.</p>
           </div>
-          <div class="faq-item">
-            <div class="faq-q">Do patrons need an account or login?</div>
-            <p class="faq-a">No. Any patron can access any module directly from the URL — no registration, no email, no personal data required.</p>
+          <div class="lib-faq__item">
+            <p class="lib-faq__q">Do patrons need an account or login?</p>
+            <p class="lib-faq__a">No. Any patron can access any module directly from the URL — no registration, no email, no personal data required.</p>
           </div>
-          <div class="faq-item">
-            <div class="faq-q">What devices and browsers are supported?</div>
-            <p class="faq-a">Any modern browser on any device: tablet, phone, or desktop. The site is WCAG 2.1 AA accessible, mobile-responsive, and tested on Android Chrome and iOS Safari. No download or installation required.</p>
+          <div class="lib-faq__item">
+            <p class="lib-faq__q">What devices and browsers are supported?</p>
+            <p class="lib-faq__a">Any modern browser on any device: tablet, phone, or desktop. The site is WCAG 2.2 AA accessible, mobile-responsive, and tested on Android Chrome and iOS Safari. No download or installation required.</p>
           </div>
-          <div class="faq-item">
-            <div class="faq-q">Can we add our organisation's branding?</div>
-            <p class="faq-a">Yes — Community tier partners receive custom branding: your logo, contact information, and optionally a landing page configured for your community. Starter and Standard tiers use DCC's standard design.</p>
+          <div class="lib-faq__item">
+            <p class="lib-faq__q">Can we add our organisation's branding?</p>
+            <p class="lib-faq__a">Yes — Community tier partners receive custom branding: your logo, contact information, and optionally a landing page configured for your community. Starter and Standard tiers use DCC's standard design.</p>
           </div>
-          <div class="faq-item">
-            <div class="faq-q">How do we use DCC in an NHSP application?</div>
-            <p class="faq-a">Community tier includes direct support scoping your NHSP project application. DCC provides the curriculum; you provide the community venue and facilitation. We can help draft the digital literacy component of your project description. Book a call to start that conversation.</p>
+          <div class="lib-faq__item">
+            <p class="lib-faq__q">How do we use DCC in an NHSP application?</p>
+            <p class="lib-faq__a">Community tier includes direct support scoping your NHSP project application. DCC provides the curriculum; you provide the community venue and facilitation. We can help draft the digital literacy component of your project description. Book a call to start that conversation.</p>
           </div>
-          <div class="faq-item">
-            <div class="faq-q">What is Two Birds Innovation?</div>
-            <p class="faq-a">Two Birds Innovation is an independent AI strategy consultancy based in St. Thomas, Ontario. Digital Confidence Centre is our flagship community product — built by a former product executive with 20+ years in digital, specifically to address the digital literacy gap in Canadian communities.</p>
+          <div class="lib-faq__item">
+            <p class="lib-faq__q">What is Two Birds Innovation?</p>
+            <p class="lib-faq__a">Two Birds Innovation is an independent AI strategy consultancy based in St. Thomas, Ontario. Digital Confidence Centre is our flagship community product — built by a former product executive with 20+ years in digital, specifically to address the digital literacy gap in Canadian communities.</p>
           </div>
         </div>
-      </section>
-
-    </div><!-- /.page -->
+      </div>
+    </section>
 
     <!-- CTA -->
-    <section class="cta-section" aria-labelledby="cta-heading">
-      <h2 id="cta-heading">Ready to bring AI literacy to your community?</h2>
-      <p>A 30-minute call is enough to see the platform, discuss your needs, and understand which tier fits. No commitment required.</p>
-      <a href="https://calendly.com/twobirdsinnovation/30min" class="btn-primary" target="_blank" rel="noopener noreferrer">Book a 30-minute demo</a>
-      <p class="cta-contact">
-        Prefer email? <a href="mailto:aaron.patzalek@gmail.com">aaron.patzalek@gmail.com</a><br>
-        Aaron Patzalek — Two Birds Innovation — St. Thomas, Ontario
-      </p>
+    <section class="dcc-section dcc-section--brand dcc-cta-band" aria-labelledby="cta-heading">
+      <div class="dcc-shell">
+        <h2 id="cta-heading">Ready to bring AI literacy to your community?</h2>
+        <p>A 30-minute call is enough to see the platform, discuss your needs, and understand which tier fits. No commitment required.</p>
+        <div class="dcc-hero__actions">
+          <a href="https://calendly.com/twobirdsinnovation/30min" class="dcc-btn dcc-btn--on-dark" target="_blank" rel="noopener noreferrer">Book a 30-minute demo</a>
+        </div>
+        <p style="margin-top:var(--space-6)">
+          Prefer email? <a href="mailto:aaron.patzalek@gmail.com" style="color:var(--color-text-inverse);text-decoration:underline">aaron.patzalek@gmail.com</a><br>
+          Aaron Patzalek — Two Birds Innovation — St. Thomas, Ontario
+        </p>
+      </div>
     </section>
 
   </main>
 
   <!-- Footer -->
-  <footer class="footer">
-    <p>&copy; 2026 Two Birds Innovation. Digital Confidence Centre. St. Thomas, Ontario, Canada.</p>
-    <div style="display: flex; gap: 20px; flex-wrap: wrap;">
-      <a href="index.html">Learner site</a>
-      <a href="privacy.html">Privacy Policy</a>
-      <a href="terms.html">Terms</a>
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <p class="footer-brand">Digital Confidence Centre</p>
+      <p class="footer-tagline">For libraries, settlement agencies &amp; community organisations</p>
+      <nav class="footer-links" aria-label="Footer navigation">
+        <a href="index.html">Learner site</a> |
+        <a href="institutional.html">NHSP application guide</a> |
+        <a href="facilitator-guide.html">Facilitator guide</a> |
+        <a href="privacy.html">Privacy Policy</a> |
+        <a href="terms.html">Terms</a>
+      </nav>
+      <p class="footer-copy">&copy; 2026 Two Birds Innovation. Digital Confidence Centre. St. Thomas, Ontario, Canada.</p>
     </div>
   </footer>
 
+  <script src="js/app.js" defer></script>
+  <script src="js/accessibility.js" defer></script>
+  <script src="js/settings.js" defer></script>
+  <script src="js/lang-toggle.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="css/accessibility.css">
   <link rel="stylesheet" href="css/mobile.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <!-- Google Search Console — Aaron: replace with real verification code from GSC dashboard -->
   <!-- <meta name="google-site-verification" content="REPLACE_WITH_REAL_CODE" /> -->
   <!-- SEO: Author, Robots, Open Graph, Twitter Card -->
@@ -306,9 +307,9 @@
   </div>
 
   <!-- Location Bar -->
-  <div id="dcc-location-bar" style="background:#E6FAF8;border-bottom:1px solid #B2DFDB;padding:6px 16px;font-size:0.88rem;color:#1B3A4B;display:flex;align-items:center;justify-content:center;gap:8px;flex-wrap:wrap;">
+  <div id="dcc-location-bar" style="background:var(--color-surface-primary);border-bottom:1px solid var(--color-border);padding:var(--space-2) var(--space-4);font-size:var(--font-size-sm);color:var(--color-text);display:flex;align-items:center;justify-content:center;gap:var(--space-2);flex-wrap:wrap;">
     <span class="location-label" data-en="Showing general Canadian resources" data-fr="Ressources canadiennes générales">Showing general Canadian resources</span>
-    <button onclick="changeLocation()" class="location-change" style="background:none;border:none;color:#2A7B6F;cursor:pointer;font-size:0.88rem;text-decoration:underline;padding:4px 8px;min-height:44px;font-family:inherit;" data-en="Set my location" data-fr="Définir ma position">Set my location</button>
+    <button onclick="changeLocation()" class="location-change" style="background:none;border:none;color:var(--color-text-link);cursor:pointer;font-size:var(--font-size-sm);text-decoration:underline;padding:var(--space-1) var(--space-2);min-height:var(--tap-target-min);font-family:inherit;" data-en="Set my location" data-fr="Définir ma position">Set my location</button>
   </div>
 
   <!-- Top Bar (Mobile) -->
@@ -654,8 +655,8 @@
           </div>
         </a>
 
-        <div class="module-category-divider" style="grid-column:1/-1;margin:1rem 0 0.25rem;padding-top:1.25rem;border-top:2px solid var(--border-color,#e0e0e0);">
-          <span style="font-size:0.8rem;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:#595959;">Expanding Your Horizons</span>
+        <div class="module-category-divider" style="grid-column:1/-1;margin:var(--space-4) 0 var(--space-1);padding-top:var(--space-5);border-top:2px solid var(--color-border);">
+          <span style="font-size:var(--font-size-sm);font-weight:var(--font-weight-bold);text-transform:uppercase;letter-spacing:var(--letter-spacing-wide);color:var(--color-text-light);">Expanding Your Horizons</span>
         </div>
 
         <a href="module-18-staying-connected.html" class="module-card" data-module="18">
@@ -743,7 +744,7 @@
         <h2 id="whats-new-heading" data-en="What's New" data-fr="Quoi de neuf">What's New</h2>
         <p data-en="Recent additions and updates to the Digital Confidence Centre." data-fr="Ajouts et mises à jour récents au Centre de confiance numérique.">Recent additions and updates to the Digital Confidence Centre.</p>
         <div id="whats-new-cards" class="module-grid" style="margin-top:1rem;">
-          <p id="whats-new-loading" style="color:#595959;font-size:0.95rem;" data-en="Loading updates..." data-fr="Chargement des mises à jour...">Loading updates...</p>
+          <p id="whats-new-loading" style="color:var(--color-text-light);" data-en="Loading updates..." data-fr="Chargement des mises à jour...">Loading updates...</p>
         </div>
       </section>
       <script>
@@ -767,10 +768,10 @@
                 card.innerHTML =
                   '<div class="card-icon" aria-hidden="true">' + item.icon + '</div>' +
                   '<div class="card-content">' +
-                    '<span style="font-size:0.78rem;color:#595959;display:block;margin-bottom:0.25rem;">' + date + '</span>' +
+                    '<span style="font-size:var(--font-size-caption);color:var(--color-text-light);display:block;margin-bottom:0.25rem;">' + date + '</span>' +
                     '<h3 style="margin:0 0 0.4rem;">' + title + '</h3>' +
                     '<p style="margin:0 0 0.5rem;">' + desc + '</p>' +
-                    '<a href="' + item.link + '" style="font-size:0.85rem;color:#2A7B6F;font-weight:600;">' + readLabel + '</a>' +
+                    '<a href="' + item.link + '" style="font-size:var(--font-size-sm);color:var(--color-text-link);font-weight:var(--font-weight-semibold);">' + readLabel + '</a>' +
                   '</div>';
                 container.appendChild(card);
               });
@@ -788,22 +789,21 @@
       <!-- ===== End This Week's Tip ===== -->
 
       <!-- ===== Scam Alert of the Month ===== -->
-      <section id="scam-of-the-month" aria-labelledby="sotm-heading" style="margin:2rem 0;padding:1.25rem 1.5rem;background:#fff3f3;border:3px solid #c0392b;border-radius:8px;">
-        <div id="sotm-loading" style="color:#595959;font-size:0.95rem;" data-en="Loading scam alert..." data-fr="Chargement de l'alerte...">Loading scam alert...</div>
+      <section id="scam-of-the-month" class="dcc-callout dcc-callout--danger" aria-labelledby="sotm-heading">
+        <div id="sotm-loading" data-en="Loading scam alert..." data-fr="Chargement de l'alerte...">Loading scam alert...</div>
         <div id="sotm-content" style="display:none;">
-          <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-bottom:0.5rem;">
-            <span style="font-size:1.4rem;" aria-hidden="true">🚨</span>
-            <h2 id="sotm-heading" style="margin:0;font-size:1.1rem;color:#b71c1c;" data-en="Scam Alert of the Month" data-fr="Arnaque du mois">Scam Alert of the Month</h2>
-            <span id="sotm-month" style="font-size:0.85rem;color:#595959;"></span>
-            <span id="sotm-severity" style="display:inline-block;background:#c0392b;color:#fff;font-size:0.75rem;font-weight:bold;padding:2px 9px;border-radius:4px;text-transform:uppercase;letter-spacing:0.05em;"></span>
-          </div>
-          <p id="sotm-title" style="font-weight:bold;font-size:1.05rem;margin:0.25rem 0 0.5rem;color:#1a1a1a;"></p>
-          <p id="sotm-summary" style="margin:0.25rem 0 0.75rem;line-height:1.6;"></p>
+          <h2 id="sotm-heading" class="dcc-callout__title" data-en="Scam Alert of the Month" data-fr="Arnaque du mois">
+            <span aria-hidden="true">🚨</span> Scam Alert of the Month
+            <span id="sotm-month" class="topic-tag"></span>
+            <span id="sotm-severity" class="topic-tag"></span>
+          </h2>
+          <p id="sotm-title" style="font-weight:var(--font-weight-bold)"></p>
+          <p id="sotm-summary"></p>
           <strong id="sotm-todo-label" data-en="What to do:" data-fr="Que faire :">What to do:</strong>
-          <ul id="sotm-todo-list" style="margin:0.5rem 0 0.75rem 1.25rem;padding:0;line-height:1.7;"></ul>
-          <div style="display:flex;flex-wrap:wrap;gap:0.75rem;margin-top:0.75rem;">
-            <a id="sotm-link-alerts" href="scam-alerts/" style="display:inline-block;background:#c0392b;color:#fff;padding:0.5rem 1rem;border-radius:5px;text-decoration:none;font-size:0.9rem;font-weight:bold;" data-en="See All Scam Alerts →" data-fr="Voir toutes les alertes →">See All Scam Alerts →</a>
-            <a id="sotm-link-sim" href="scam-simulator.html" style="display:inline-block;background:#fff;color:#c0392b;border:2px solid #c0392b;padding:0.5rem 1rem;border-radius:5px;text-decoration:none;font-size:0.9rem;font-weight:bold;" data-en="Practise Spotting Scams →" data-fr="S'entraîner à repérer les arnaques →">Practise Spotting Scams →</a>
+          <ul id="sotm-todo-list"></ul>
+          <div class="dcc-callout__actions">
+            <a id="sotm-link-alerts" href="scam-alerts/" class="dcc-btn dcc-btn--primary" data-en="See All Scam Alerts →" data-fr="Voir toutes les alertes →">See All Scam Alerts →</a>
+            <a id="sotm-link-sim" href="scam-simulator.html" class="dcc-btn dcc-btn--secondary" data-en="Practise Spotting Scams →" data-fr="S'entraîner à repérer les arnaques →">Practise Spotting Scams →</a>
           </div>
         </div>
       </section>
@@ -873,18 +873,18 @@
       </div>
 
       <!-- My Progress -->
-      <div id="dcc-progress-widget" style="display:none;background:#fff;border:1.5px solid var(--color-primary,#2A7B6F);border-radius:14px;padding:1.25rem 1.5rem;margin-bottom:2rem">
-        <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap">
+      <div id="dcc-progress-widget" style="display:none;background:var(--color-bg);border:1.5px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-bottom:var(--space-8)">
+        <div style="display:flex;align-items:center;gap:var(--space-3);flex-wrap:wrap">
           <div style="flex:1;min-width:0">
-            <p style="font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.07em;color:var(--color-primary,#2A7B6F);margin-bottom:0.2rem">Your Progress</p>
-            <p style="font-size:1rem;font-weight:700;color:var(--color-text,#3D3229)" id="dcc-progress-text">0 of 29 modules with results</p>
-            <div style="height:6px;background:#e0f0ee;border-radius:3px;margin-top:0.5rem;overflow:hidden">
-              <div id="dcc-progress-bar" style="height:100%;background:var(--color-primary,#2A7B6F);border-radius:3px;transition:width 0.4s;width:0%"></div>
+            <p style="font-size:var(--font-size-sm);font-weight:var(--font-weight-bold);text-transform:uppercase;letter-spacing:var(--letter-spacing-wide);color:var(--color-primary);margin-bottom:0.2rem">Your Progress</p>
+            <p style="font-size:var(--font-size-base);font-weight:var(--font-weight-bold);color:var(--color-text)" id="dcc-progress-text">0 of 29 modules with results</p>
+            <div style="height:8px;background:var(--color-primary-light);border-radius:var(--radius-sm);margin-top:var(--space-2);overflow:hidden">
+              <div id="dcc-progress-bar" style="height:100%;background:var(--color-primary);border-radius:var(--radius-sm);transition:width 0.4s;width:0%"></div>
             </div>
           </div>
-          <a href="digital-literacy-101.html" class="btn-primary" style="display:inline-block;background:var(--color-primary,#2A7B6F);color:#fff;border-radius:50px;padding:0.55rem 1.25rem;font-size:0.85rem;font-weight:700;text-decoration:none;white-space:nowrap">Continue learning →</a>
+          <a href="digital-literacy-101.html" class="dcc-btn dcc-btn--primary" style="white-space:nowrap">Continue learning →</a>
         </div>
-        <p style="font-size:0.75rem;color:var(--color-text-light,#7A6E62);margin-top:0.6rem" id="dcc-progress-detail"></p>
+        <p style="font-size:var(--font-size-caption);color:var(--color-text-light);margin-top:var(--space-2)" id="dcc-progress-detail"></p>
       </div>
 
       <!-- Canadian Government Benefits -->
@@ -892,49 +892,49 @@
       <p>Many Canadian seniors are missing government benefits they have already earned. These free guides explain what you qualify for, how to check, and how to apply — in plain language, step by step.</p>
 
       <div class="module-grid">
-        <a href="resources/gis-guide.html" class="module-card" style="border-top:4px solid #c8960c">
+        <a href="resources/gis-guide.html" class="module-card dcc-top--warning">
           <div class="card-icon" aria-hidden="true">💰</div>
           <div class="card-content">
             <h3>Guaranteed Income Supplement</h3>
             <p>Up to $1,065/month extra for low-income seniors who receive OAS. Non-taxable. Many eligible seniors have never applied. Includes 11-month back payment rule.</p>
           </div>
         </a>
-        <a href="resources/dental-care-guide.html" class="module-card" style="border-top:4px solid #2e7d32">
+        <a href="resources/dental-care-guide.html" class="module-card dcc-top--success">
           <div class="card-icon" aria-hidden="true">🦷</div>
           <div class="card-content">
             <h3>Canada Dental Care Plan</h3>
             <p>Free or subsidised dental care for seniors without private insurance and income under $90,000. Millions of eligible Canadians have not yet enrolled.</p>
           </div>
         </a>
-        <a href="resources/cra-guide.html" class="module-card" style="border-top:4px solid #2A7B6F">
+        <a href="resources/cra-guide.html" class="module-card dcc-top--brand">
           <div class="card-icon" aria-hidden="true">🍁</div>
           <div class="card-content">
             <h3>CRA My Account</h3>
             <p>View your tax refund, set up direct deposit, check your RRSP room, and manage your tax file — without calling CRA or waiting on hold.</p>
           </div>
         </a>
-        <a href="resources/service-canada-guide.html" class="module-card" style="border-top:4px solid #1565C0">
+        <a href="resources/service-canada-guide.html" class="module-card dcc-top--info">
           <div class="card-icon" aria-hidden="true">🇨🇦</div>
           <div class="card-content">
             <h3>My Service Canada Account</h3>
             <p>Your CPP and OAS payment dates, direct deposit, and T4A tax slips — all online, no hold music required.</p>
           </div>
         </a>
-        <a href="resources/ontario-trillium-benefit.html" class="module-card" style="border-top:4px solid #2e7d32">
+        <a href="resources/ontario-trillium-benefit.html" class="module-card dcc-top--success">
           <div class="card-icon" aria-hidden="true">🌷</div>
           <div class="card-content">
             <h3>Ontario Trillium Benefit</h3>
             <p>Up to $1,421/year for eligible Ontario residents — applied for on Schedule ON-BEN of your tax return. Easy to miss, easy to claim retroactively.</p>
           </div>
         </a>
-        <a href="resources/cpp-start-date-guide.html" class="module-card" style="border-top:4px solid #1a2744">
+        <a href="resources/cpp-start-date-guide.html" class="module-card dcc-top--brand">
           <div class="card-icon" aria-hidden="true">📅</div>
           <div class="card-content">
             <h3>When to Start CPP</h3>
             <p>Waiting from 65 to 70 adds 42% to your CPP — permanently. Starting at 60 cuts it by 36%. The break-even age and the four factors that drive the decision.</p>
           </div>
         </a>
-        <a href="resources/serviceontario-guide.html" class="module-card" style="border-top:4px solid #1565C0">
+        <a href="resources/serviceontario-guide.html" class="module-card dcc-top--info">
           <div class="card-icon" aria-hidden="true">🏛️</div>
           <div class="card-content">
             <h3>ServiceOntario Online</h3>
@@ -942,9 +942,9 @@
           </div>
         </a>
       </div>
-      <p style="text-align:center;margin-top:1rem;font-size:0.9rem">
-        <a href="resources/index.html" style="color:var(--color-primary,#2A7B6F);font-weight:600">→ See all 27 Canadian benefits and financial guides</a>
-        <span style="color:var(--color-text-light,#7A6E62)"> — GIS, RDSP, CPP, OAS, ODB, GST/HST Credit, CPP Survivor's Pension, Allowance, and more</span>
+      <p class="dcc-center" style="margin-top:var(--space-4);font-size:var(--font-size-sm)">
+        <a href="resources/index.html" style="color:var(--color-text-link);font-weight:var(--font-weight-semibold)">→ See all 27 Canadian benefits and financial guides</a>
+        <span style="color:var(--color-text-light)"> — GIS, RDSP, CPP, OAS, ODB, GST/HST Credit, CPP Survivor's Pension, Allowance, and more</span>
       </p>
 
       <!-- AI Literacy Feature -->
@@ -952,7 +952,7 @@
       <p>AI tools are already on your phone, at your doctor's office, and in your email. This free module explains what they actually do, when they help, and how to stay safe — including the 3-Second Rule for avoiding scams.</p>
 
       <div class="module-grid">
-        <a href="module-ai-literacy.html" class="module-card" style="border-top:4px solid #3949ab">
+        <a href="module-ai-literacy.html" class="module-card dcc-top--brand">
           <div class="card-icon" aria-hidden="true">🤖</div>
           <div class="card-content">
             <h3>What Is AI, Really? — Adults 55+</h3>
@@ -1169,43 +1169,45 @@
       <!-- ===== End Testimonials ===== -->
 
       <!-- ===== In the News ===== -->
-      <section id="dcc-news-feed" aria-labelledby="dcc-news-heading" style="margin:2rem 0;padding:1.5rem 1.75rem;background:#f0f6ff;border:1px solid #c5d8f5;border-radius:8px;">
-        <h2 id="dcc-news-heading" style="font-size:1.15rem;color:#1a3c5e;margin:0 0 0.9rem;" data-en="AI &amp; Digital Safety in the News" data-fr="L&#x2019;IA et la s&#x00E9;curit&#x00E9; num&#x00E9;rique dans les nouvelles">AI &amp; Digital Safety in the News</h2>
-        <ul id="dcc-news-list" style="list-style:none;padding:0;margin:0 0 0.75rem;">
-          <li style="color:#666;font-style:italic;" data-en="Loading latest news&hellip;" data-fr="Chargement des nouvelles&hellip;">Loading latest news&hellip;</li>
+      <section id="dcc-news-feed" class="dcc-callout dcc-callout--info" aria-labelledby="dcc-news-heading">
+        <h2 id="dcc-news-heading" class="dcc-callout__title" data-en="AI &amp; Digital Safety in the News" data-fr="L&#x2019;IA et la s&#x00E9;curit&#x00E9; num&#x00E9;rique dans les nouvelles">AI &amp; Digital Safety in the News</h2>
+        <ul id="dcc-news-list" style="list-style:none;padding:0;margin:0 0 var(--space-3);">
+          <li data-en="Loading latest news&hellip;" data-fr="Chargement des nouvelles&hellip;">Loading latest news&hellip;</li>
         </ul>
-        <p style="font-size:0.8rem;color:#5a6a7e;margin:0;" data-en="Source: CBC Technology &bull; Updated daily" data-fr="Source&#xA0;: CBC Technologie &bull; Mis &#x00E0; jour quotidiennement">Source: CBC Technology &bull; Updated daily</p>
+        <p style="font-size:var(--font-size-caption);color:var(--color-text-light);margin:0;" data-en="Source: CBC Technology &bull; Updated daily" data-fr="Source&#xA0;: CBC Technologie &bull; Mis &#x00E0; jour quotidiennement">Source: CBC Technology &bull; Updated daily</p>
       </section>
       <style>
-        .dcc-news-item { padding: 0.5rem 0; border-bottom: 1px solid #dce8f8; }
-        .dcc-news-item:last-child { border-bottom: none; }
-        .dcc-news-link { font-size: 1rem; color: #1a3c5e; font-weight: 500; }
-        .dcc-news-link:hover { text-decoration: underline; }
-        .dcc-news-date { display: block; font-size: 0.8rem; color: #6b7c93; margin-top: 0.15rem; }
-        .dcc-news-empty { color: #555; font-style: italic; }
+        #dcc-news-feed .dcc-news-item { padding: var(--space-2) 0; border-bottom: 1px solid var(--color-border); }
+        #dcc-news-feed .dcc-news-item:last-child { border-bottom: none; }
+        #dcc-news-feed .dcc-news-link { font-size: var(--font-size-base); color: var(--color-text-link); font-weight: var(--font-weight-semibold); }
+        #dcc-news-feed .dcc-news-link:hover { text-decoration: underline; }
+        #dcc-news-feed .dcc-news-date { display: block; font-size: var(--font-size-caption); color: var(--color-text-light); margin-top: var(--space-1); }
+        #dcc-news-feed .dcc-news-empty { color: var(--color-text-light); }
       </style>
       <!-- ===== End In the News ===== -->
 
       <!-- ===== Share DCC ===== -->
-      <section class="share-dcc-section" style="background:#E8F5E9;padding:2.5rem 1.5rem;text-align:center;margin-top:2rem;">
-        <div style="max-width:640px;margin:0 auto;">
-          <h2 style="font-size:1.4rem;color:#1B5E20;margin-bottom:0.75rem;"
+      <section class="share-dcc-section dcc-callout dcc-callout--success dcc-center">
+        <div class="dcc-measure" style="margin:0 auto;">
+          <h2 class="dcc-callout__title" style="justify-content:center;"
               data-en="Know a senior who could benefit?"
               data-fr="Vous connaissez un aîné qui pourrait en bénéficier?">
             Know a senior who could benefit?
           </h2>
-          <p style="font-size:1.05rem;color:#2E7D32;margin-bottom:1.25rem;"
+          <p style="font-size:var(--font-size-lead);"
              data-en="The Digital Confidence Centre is completely free. Share it with a friend, neighbour, or family member who uses an iPad or smartphone."
              data-fr="Le Centre de confiance numérique est entièrement gratuit. Partagez-le avec un ami, un voisin ou un membre de la famille qui utilise un iPad ou un téléphone intelligent.">
             The Digital Confidence Centre is completely free. Share it with a friend, neighbour, or family member who uses an iPad or smartphone.
           </p>
-          <a href="mailto:?subject=A%20free%20digital%20learning%20programme%20for%20seniors&body=Hi%2C%0A%0AI%20wanted%20to%20share%20something%20I%20found%20that%20you%20might%20find%20really%20helpful.%0A%0AThe%20Digital%20Confidence%20Centre%20is%20a%20free%20online%20learning%20programme%20for%20Canadian%20seniors.%20It%20covers%20everything%20from%20staying%20safe%20from%20scams%20to%20using%20apps%20and%20video%20calls.%20No%20sign-up%20needed.%0A%0AYou%20can%20visit%20it%20here%3A%20https%3A%2F%2Fdigitalconfidencecentre.ca%0A%0AHope%20you%20find%20it%20useful!"
-             style="display:inline-block;background:#2E7D32;color:#fff;padding:0.75rem 1.75rem;border-radius:8px;font-size:1.05rem;font-weight:600;text-decoration:none;"
-             data-en="✉ Send this link by email"
-             data-fr="✉ Envoyer ce lien par courriel">
-            ✉ Send this link by email
-          </a>
-          <p style="margin-top:1rem;font-size:0.9rem;color:#388E3C;"
+          <div class="dcc-callout__actions" style="justify-content:center;">
+            <a href="mailto:?subject=A%20free%20digital%20learning%20programme%20for%20seniors&body=Hi%2C%0A%0AI%20wanted%20to%20share%20something%20I%20found%20that%20you%20might%20find%20really%20helpful.%0A%0AThe%20Digital%20Confidence%20Centre%20is%20a%20free%20online%20learning%20programme%20for%20Canadian%20seniors.%20It%20covers%20everything%20from%20staying%20safe%20from%20scams%20to%20using%20apps%20and%20video%20calls.%20No%20sign-up%20needed.%0A%0AYou%20can%20visit%20it%20here%3A%20https%3A%2F%2Fdigitalconfidencecentre.ca%0A%0AHope%20you%20find%20it%20useful!"
+               class="dcc-btn dcc-btn--primary"
+               data-en="✉ Send this link by email"
+               data-fr="✉ Envoyer ce lien par courriel">
+              ✉ Send this link by email
+            </a>
+          </div>
+          <p style="margin-top:var(--space-4);font-size:var(--font-size-sm);color:var(--color-text-light);"
              data-en="Or copy the address: digitalconfidencecentre.ca"
              data-fr="Ou copiez l'adresse : digitalconfidencecentre.ca">
             Or copy the address: digitalconfidencecentre.ca

--- a/resources.html
+++ b/resources.html
@@ -24,6 +24,7 @@
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="css/accessibility.css">
   <link rel="stylesheet" href="css/mobile.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <!-- SEO: Author, Robots, Open Graph, Twitter Card -->
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
@@ -241,7 +242,7 @@
         Every resource on this page is free, trustworthy, and staffed by people who genuinely want to help you. When in doubt, call. There are no silly questions.
       </div>
 
-      <div class="resource-card" style="border-top: 4px solid #1565C0;background:var(--bg-secondary,#f0f4ff)">
+      <div class="resource-card dcc-top--info" style="background:var(--color-surface)">
         <h3 style="margin-top:0">🏡 <a href="resources/living-alone.html">Living Alone Safely — Digital Guide for Solo Seniors</a></h3>
         <p>A complete guide covering smart home devices, health technology, financial safety, emergency preparedness, and staying connected — written specifically for seniors who live independently in Ontario.</p>
         <a href="resources/living-alone.html" class="btn btn-primary" style="display:inline-block;margin-top:0.5rem">Read the Guide →</a>

--- a/styleguide/SENIOR-ACCESSIBLE-RESEARCH-2026.md
+++ b/styleguide/SENIOR-ACCESSIBLE-RESEARCH-2026.md
@@ -1,0 +1,124 @@
+# Research — Best-in-class accessible platforms (2026-06-18)
+
+Reference research for the **DCC UI Rebuild v1**. We studied three platforms
+recognised for accessible design serving older adults, health audiences, and
+the public — exactly the people libraries and nonprofits support. For each we
+extracted the conventions that matter to DCC (colour, typography, spacing,
+navigation, layout) and recorded how the rebuild applies them.
+
+Selected for being *measurably* accessible, openly documented, and aimed at the
+same "anxious, careful, often-older, mixed-ability" reader DCC serves:
+
+1. **GOV.UK Design System** — `design-system.service.gov.uk`
+2. **NHS digital service manual** — `service-manual.nhs.uk`
+3. **Senior Planet / AARP OATS** — `seniorplanet.org` (older-adult digital literacy)
+
+(Cross-reference: **Canada.ca / Canada.ca design system** informs our bilingual
+EN/FR rules — see `DESIGN-SYSTEM.md` §8.)
+
+---
+
+## 1. GOV.UK Design System
+
+The reference standard for accessible public-service interfaces. Built to work
+for the whole population, including low-confidence and assistive-tech users.
+
+**Colour**
+- Near-black body text (`#0b0c0c`) on white — maximum legibility, never grey body.
+- One strong link colour (`#1d70b8`) used consistently; visited and hover states differ.
+- A single decisive primary action colour (green `#00703c`); destructive actions are a separate red.
+- A loud focus state: solid **yellow** highlight (`#ffdd00`) with a thick black underline — impossible to miss with a keyboard.
+
+**Typography**
+- ~19px body on desktop, ~16px on mobile; generous line-height (~1.25–1.5).
+- One humanist sans for everything; weight, not colour, signals hierarchy.
+
+**Spacing & layout**
+- A fixed responsive spacing scale (multiples of a base unit) — never arbitrary gaps.
+- Single readable column; constrained measure (~two-thirds width) so lines don't tire the eye.
+
+**Navigation**
+- **One thing per page.** One question / one task per screen; navigation recedes.
+- Errors summarised at the top and repeated inline, always prefixed "Error:".
+
+**→ DCC applies:** decisive single primary action (`--color-accent-strong`),
+near-black body (`--color-text` #1A1A2E, 16:1), constrained `--content-max`
+(72ch), unmistakable focus ring, and the "one thing per screen" module pattern.
+
+---
+
+## 2. NHS digital service manual
+
+Designed for a health audience that skews older and anxious — the closest peer
+to DCC's emotional context ("I'm worried, explain it simply").
+
+**Colour**
+- NHS blue (`#005eb8`) as the trusted brand/action colour; white text on blue passes AA.
+- Warning/expander components use a bold dark text on pale background, never colour alone to carry meaning.
+- A high-visibility focus state (yellow with black) consistent across all components.
+
+**Typography**
+- ~19px desktop body; the **lead paragraph is set larger** to lower the initial reading burden.
+- No italics, no justified text (both harm dyslexic and screen-magnifier users).
+- Plain English at a low reading age; short sentences, one idea each.
+
+**Spacing & layout**
+- Generous vertical rhythm; clear card and "care card" patterns with coloured left borders to classify information (e.g. urgent vs non-urgent).
+- Consistent component positions — help/contact appears in the same place every time.
+
+**Navigation**
+- Predictable, shallow structure; "back" is always available; breadcrumb on deep pages.
+
+**→ DCC applies:** larger `--font-size-lead`, no italics / no justify rules,
+left-border "care card" classification reused directly in our new
+`.dcc-callout` (brand / info / success / warning / danger), and the
+"help in the same place" rule (WCAG 2.2 SC 3.2.6).
+
+---
+
+## 3. Senior Planet / AARP OATS
+
+A digital-literacy programme built *specifically* for older adults, delivered
+through libraries and community centres — DCC's direct analogue.
+
+**Colour**
+- High contrast, warm and friendly rather than clinical; large solid blocks of colour, minimal subtle greys.
+- Photography of real older adults, not abstract tech imagery.
+
+**Typography**
+- Large type by default (well above 16px); short headings in plain language ("Get Started", "Find a Class").
+
+**Spacing & layout**
+- Very generous whitespace and big tap targets; few items per screen.
+- Step-by-step lessons with one action per step and a screenshot/illustration.
+
+**Navigation**
+- Shallow, plain-language top nav; obvious "where do I start" entry point.
+- Clear separation between *learners* and *organisations who run programmes* — two doorways, plainly labelled.
+
+**→ DCC applies:** warm "kitchen-table" palette (already our Warm Hearth theme),
+56px touch targets, big readable type, numbered single-action steps
+(`.dcc-steps`), real-senior photography, and an explicit two-doorway home
+(learners vs libraries/organisations).
+
+---
+
+## Extracted conventions → DCC tokens & components
+
+| Convention (from the three platforms) | DCC implementation |
+|---|---|
+| Near-black body, never grey | `--color-text` `#1A1A2E` (16.3:1) |
+| One decisive primary action colour, AA-safe | `--color-accent-strong` `#A85410` (5.33:1) on `.dcc-btn--primary` |
+| Loud, always-visible focus | `--focus-ring` 3px `--color-accent-strong`, 2px offset |
+| ~19px+ body, larger lead paragraph | `--font-size-base` 19px; `--font-size-lead` clamp(20–24px) |
+| Fixed spacing scale, no arbitrary gaps | `--space-*` 4px scale only |
+| Constrained readable measure | `--content-max` 72ch |
+| Colour-coded info cards w/ left border | `.dcc-callout--brand/info/success/warning/danger` |
+| One thing per screen / shallow nav | module page pattern; grouped sidebar (Get Started / Lessons / Resources) |
+| Two clear doorways (learner vs org) | rebuilt `index.html` audience split + `for-libraries.html` |
+| Big tap targets | `--tap-target` 56px |
+| No italics / no justify / left-align | enforced in `DESIGN-SYSTEM.md` §8 + `dcc-core.css` |
+| Real-people photography | hero imagery of older Canadians (existing assets) |
+
+These three references, plus Canada.ca's bilingual content standard, are the
+basis for the token and component decisions shipped in this rebuild.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A first, non-destructive rebuild of the Digital Confidence Centre's UI, UX, and information architecture around a verified, accessible design system. The site is large, SEO-rich, and JS-coupled, so this v1 establishes the foundation and rebuilds the **three front-door pages** rather than rewriting 300+ pages at once. All SEO `<head>`/schema, navigation links, content, and JavaScript hooks are preserved.

## What's in this PR

### 1. Audit — what exists today
`_audit/ui-ux-ia-audit-2026-06-18.md` documents every page group, the CSS/JS architecture, the component inventory, the IA, and the key findings driving the rebuild (notably: an accent colour that fails contrast as a button, heavy off-token inline styling, and a `for-libraries.html` page running its own parallel design system).

### 2. Research — 3 best-in-class accessible platforms
`styleguide/SENIOR-ACCESSIBLE-RESEARCH-2026.md` extracts the colour, typography, spacing, navigation, and layout conventions of **GOV.UK Design System**, the **NHS digital service manual**, and **Senior Planet / AARP OATS**, and maps each convention to a concrete DCC token or component.

### 3. Design tokens — verified WCAG 2.2 AA
`css/tokens.css` (+ dark and high-contrast variants) hardened and documented:
- **Fixes a real contrast defect:** white-on-`--color-accent` (#E8842C) was **2.7:1** (fails). Added `--color-accent-strong` (#A85410, **5.33:1**) for all CTA backgrounds and re-pointed the focus ring to it. `--color-accent` is now decorative-only.
- Added `--font-size-lead` for larger lead paragraphs (NHS pattern).
- Documented the verified contrast table in the file header; large readable type (19px base), generous 4px spacing scale, 56px touch targets all retained.

### 4. New token-driven layer — `css/dcc-core.css`
A clean, `.dcc-`-prefixed refinement layer loaded last (zero hardcoded values): accessible `.dcc-btn`, a single `.dcc-callout` component (brand/info/success/warning/danger) that replaces ad-hoc coloured boxes, `.dcc-top--*` card accents, and marketing primitives (hero, section, grid, card, steps, CTA band).

### 5. Rebuilt core pages
- **`index.html`** — de-inlined the scam-alert, news, share, benefit-card, location-bar and progress sections onto tokens/callouts (these previously hardcoded hex and broke in dark mode).
- **`for-libraries.html`** — fully rebuilt from a standalone off-brand navy/blue page onto the shared Warm Hearth system, with the accessibility bar, dark mode, and a larger senior-readable type scale. All content, pricing, and links preserved.
- **`resources.html`** — loaded `dcc-core.css` and tokenized its off-token card.

### 6. Governance — `AGENTS.md`
Root file governing all future agent runs: product description, target users, design principles, tech stack + hard constraints, the accessibility bar (with a copy-paste contrast-check script), localisation rules, workflow, and a concrete "what done looks like" checklist.

## Verification
- All token contrast pairs recomputed and pass WCAG 2.2 AA (table in `tokens.css`).
- HTML tag structure validated on all three rebuilt pages; CSS braces balanced.
- JS hooks (`.font-size-btn`, `.theme-toggle-btn`, `.sidebar`, `#sotm-*`, `#dcc-news-list`, `[data-en]/[data-fr]`) and IDs preserved.

## Follow-ups (tracked in the audit + AGENTS.md)
Migrate remaining inline styles on `about.html` and module pages, add `dcc-core.css` to the global include set, and retire any remaining page-private palettes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdae8e6c-6654-4228-8c35-6d65e4c89252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdae8e6c-6654-4228-8c35-6d65e4c89252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

