### PR TITLE
chore(dcc): document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+See `CLAUDE.md` for project identity, hard constraints (static-only, no backend), accessibility standards, and content rules. Those apply to all agents.
+
+## Cursor Cloud specific instructions
+
+This is a **fully static** HTML/CSS/JS site (no framework, no build step). "Running the app" means serving the repo root with a static file server; there is nothing to compile.
+
+### Services / how to run
+- **Run the site:** `http-server . -p 3000 -s --cors` from the repo root, then open `http://localhost:3000/`. Any static server works; `http-server` matches what CI uses. Start it in a tmux session so it survives between commands.
+- The site uses an onboarding modal on first load (location → device → privacy → font) and stores all state in LocalStorage. Module progress is **scroll-based**, not checkbox-based — sections mark themselves read as you scroll. The final quiz is gated until modules are started.
+
+### Lint (accessibility) — the repo's only "lint"
+- There is no ESLint/Prettier. The lint check is **axe-core** (see `.github/workflows/axe-core.yml`). CI only fails on *critical* WCAG violations; serious/moderate/minor are reported but non-blocking.
+- Run against the running server, e.g.:
+  `axe http://localhost:3000/index.html --tags wcag2a,wcag2aa,wcag21a,wcag21aa --chromedriver-path "$HOME/.npm-global/bin/chromedriver" --exit`
+- **Gotcha:** the axe CLI bundles a ChromeDriver that tracks the *latest* Chrome, but this VM's Chrome is pinned to major 148. Without `--chromedriver-path` pointing at the matching `chromedriver@148` (installed by the update script), axe fails with a "session not created / version mismatch" error.
+
+### Tests — Playwright smoke + visual
+- Harness lives in `tests/playwright/` (CI-only; its `node_modules` is gitignored). Smoke tests assert no horizontal overflow, non-blank body, and an `<h1>` across 6 pages × 5 browser projects.
+- The server on `:3000` must be running first. Then:
+  `cd tests/playwright && PW_BASE_URL=http://localhost:3000 npx playwright test smoke.spec.js`
+- `visual.spec.js` needs committed baseline snapshots and is run by `visual-regression.yml`, not the smoke workflow — don't run it ad hoc unless baselines exist.
+- Internal link helper: `node test-links.js`. **Known false positives:** it flags root-relative links like `/sitemap.xml` as broken because it resolves `/` against the filesystem root; those files do exist. Not part of CI.
+
+### Environment notes
+- npm's global prefix is set to `$HOME/.npm-global` (kept in `~/.npmrc`) so `npm install -g` works without sudo; `$HOME/.npm-global/bin` is on PATH via `~/.bashrc`. An nvm warning about an incompatible `prefix` prints on most shell invocations — it is harmless and does not affect installs.
+- The Python `generate_*.py` scripts and `scripts/*.py` are offline content generators, not part of the served app or its dev loop.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and documents the development environment for the Digital Confidence Centre (a fully static HTML/CSS/JS site — no framework or build step). No application code changed; only adds `AGENTS.md` with durable Cursor Cloud notes.

The environment now supports the three standard developer loops:

| Task | Command | Result |
|------|---------|--------|
| Run | `http-server . -p 3000 -s --cors` | ✅ serves all pages (HTTP 200) |
| Lint (a11y) | `axe http://localhost:3000/<page> --tags wcag2a,wcag2aa,wcag21a,wcag21aa --chromedriver-path "$HOME/.npm-global/bin/chromedriver" --exit` | ✅ runs (reports content-level color-contrast issues; tool functional) |
| Test | `cd tests/playwright && PW_BASE_URL=http://localhost:3000 npx playwright test smoke.spec.js` | ✅ 30 passed |

## Key notes captured in `AGENTS.md`
- axe-core's bundled ChromeDriver tracks the latest Chrome, but this VM's Chrome is pinned to major 148 — `--chromedriver-path` to `chromedriver@148` is required.
- npm global prefix is set to `$HOME/.npm-global` so `npm install -g` works without sudo (an nvm prefix warning prints but is harmless).
- Module progress is scroll-based (not checkboxes); the final quiz is gated until modules are started; `test-links.js` has known false positives for root-relative URLs.

## Hello-world verification
Loaded the home page, increased font size via the accessibility controls, navigated to Module 1, advanced the scroll-based progress tracker, and visited the final quiz page.

[dcc_hello_world_walkthrough.mp4](https://cursor.com/agents/bc-9ec6136a-7425-4978-a9f7-41d599063e68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdcc_hello_world_walkthrough.mp4)
[DCC home page](https://cursor.com/agents/bc-9ec6136a-7425-4978-a9f7-41d599063e68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdcc_home.webp)
[Font size increased via accessibility controls](https://cursor.com/agents/bc-9ec6136a-7425-4978-a9f7-41d599063e68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdcc_font_increased.webp)
[Module 1 progress tracker advancing](https://cursor.com/agents/bc-9ec6136a-7425-4978-a9f7-41d599063e68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdcc_module1_progress.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ec6136a-7425-4978-a9f7-41d599063e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ec6136a-7425-4978-a9f7-41d599063e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

