### PR TITLE
DCC v3 — Module pages design system migration (batch 2 of 10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ layer (inline styles removed, hardcoded hex/px replaced with token-driven
 classes, AA contrast verified). Tick a module only when it loads
 `css/dcc-core.css` and carries no presentational inline styles.
 
-**Batch 1 (this PR) — first 10 modules:**
+**Batch 1 — first 10 modules:**
 
 - [x] `module-1.html` — Mastering the Escape Hatch
 - [x] `module-2.html` — The Security Shield
@@ -153,6 +153,25 @@ classes, AA contrast verified). Tick a module only when it loads
 - [x] `module-9.html` — Understanding AI
 - [x] `module-10.html` — Grocery & Food Delivery
 
-**Pending (future batches):** `module-11`–`module-27` and the named modules
+**Batch 2 (this PR) — modules 11–20:**
+
+- [x] `module-11.html` — Ride-Sharing Apps
+- [x] `module-12.html` — Getting the Help You Deserve
+- [x] `module-13.html` — Understanding Social Media
+- [x] `module-14.html` — Smart Home Basics
+- [x] `module-15.html` — Telehealth & Medical Portals
+- [x] `module-16-travel-safety.html` — Staying Safe When You Travel
+- [x] `module-17-ai-research.html` — Using AI for Research
+- [x] `module-18-staying-connected.html` — Staying Connected When It Matters Most
+- [x] `module-19-digital-legacy.html` — Your Digital Life: Keeping It Safe and Organised
+- [x] `module-20-internet-plan.html` — Understanding Your Internet Plan
+
+> Note: as in batch 1, only presentational inline `style=` attributes were
+> removed. Page-embedded `<style>` blocks (still present on several of these
+> pages, e.g. module-12/14/15) were left intact and remain future work — they
+> already reference `var(--color-primary, …)` so the off-token hex values are
+> dead fallbacks, not live colours.
+
+**Pending (future batches):** `module-21`–`module-27` and the named modules
 (`module-ai-literacy`, `module-fact-check`, `module-visual-ai`, etc.) have not
 yet been migrated.

--- a/css/dcc-core.css
+++ b/css/dcc-core.css
@@ -366,6 +366,36 @@ a.btn-primary:hover,
 .dcc-data-table--filled td { padding: var(--space-3); }
 .dcc-data-table--filled tbody tr:nth-child(even) { background: var(--color-surface-alt); }
 
+/* --- 7b. Module-page refinements (DCC v3 batch 2 migration) -------------- */
+/* These replace the repeated inline styles in module-11…module-20 with
+   token-driven, AA-safe classes. As in batch 1, no content, links, or JS
+   hooks change — selectors only restyle existing attributes. */
+
+/* Summary checklist (module-11): the inline styles gave each label a
+   flex-start, padded layout so multi-line items align under the checkbox.
+   Preserve that intent on top of the shared .checklist base, token-driven. */
+.dcc-checklist { margin-bottom: var(--space-6); }
+.dcc-checklist label {
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3);
+}
+.dcc-checklist label input[type="checkbox"] {
+  margin-top: var(--space-1);
+  flex-shrink: 0;
+}
+
+/* Centre-aligned data columns (module-11 availability table): first column
+   stays left, remaining columns centre. Higher specificity than the base
+   left-aligned .dcc-data-table cells so it wins without !important. */
+.dcc-data-table--center th:not(:first-child),
+.dcc-data-table--center td:not(:first-child) { text-align: center; }
+
+/* Small supplementary note text (module-14 privacy meter): replaces the
+   off-token #666 colour and sub-floor 0.82rem with the token colour and the
+   16px senior minimum. */
+.dcc-meta-note { font-size: var(--font-size-sm); color: var(--color-text-light); }
+
 /* --- 8. Utilities -------------------------------------------------------- */
 .dcc-center { text-align: center; }
 .dcc-measure { max-width: var(--content-max); }

--- a/module-11.html
+++ b/module-11.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta property="og:url" content="https://twobirds-kramerica.github.io/digital-confidence/module-11.html">
@@ -221,10 +222,10 @@
 </head>
 <body>
   <noscript>
-    <div style="padding:20px;font-family:Georgia,serif;max-width:800px;margin:0 auto">
+    <div class="dcc-noscript">
       <h1>Digital Confidence Centre — Module 11: Ride-Sharing</h1>
 
-      <div class="dcc-quiz-container" id="dcc-before-quiz" aria-label="Knowledge check — before you start" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz" aria-label="Knowledge check — before you start"></div>
       <div class="module-intro">
         <p class="module-time">⏱ About 20–30 minutes — go at your own pace</p>
         <div class="confidence-check-box">
@@ -465,12 +466,12 @@
 
       <p>Ride-sharing is designed with safety as a priority. Here is a complete summary of your safety checklist:</p>
 
-      <div class="checklist" style="margin-bottom:24px;">
-        <label style="display:flex;align-items:flex-start;gap:12px;padding:10px;"><input type="checkbox" style="margin-top:3px;flex-shrink:0;"> <span><strong>Always check the licence plate FIRST</strong> — before the car door, before anything else</span></label>
-        <label style="display:flex;align-items:flex-start;gap:12px;padding:10px;"><input type="checkbox" style="margin-top:3px;flex-shrink:0;"> <span><strong>Let the driver greet you by name</strong> — never say their name first</span></label>
-        <label style="display:flex;align-items:flex-start;gap:12px;padding:10px;"><input type="checkbox" style="margin-top:3px;flex-shrink:0;"> <span><strong>Never get in a car that does not match the app</strong> — cancel and request again</span></label>
-        <label style="display:flex;align-items:flex-start;gap:12px;padding:10px;"><input type="checkbox" style="margin-top:3px;flex-shrink:0;"> <span><strong>Share your trip</strong> with a family member before every ride</span></label>
-        <label style="display:flex;align-items:flex-start;gap:12px;padding:10px;"><input type="checkbox" style="margin-top:3px;flex-shrink:0;"> <span><strong>Trust your instincts</strong> — if something feels wrong, end the ride</span></label>
+      <div class="checklist dcc-checklist">
+        <label><input type="checkbox"> <span><strong>Always check the licence plate FIRST</strong> — before the car door, before anything else</span></label>
+        <label><input type="checkbox"> <span><strong>Let the driver greet you by name</strong> — never say their name first</span></label>
+        <label><input type="checkbox"> <span><strong>Never get in a car that does not match the app</strong> — cancel and request again</span></label>
+        <label><input type="checkbox"> <span><strong>Share your trip</strong> with a family member before every ride</span></label>
+        <label><input type="checkbox"> <span><strong>Trust your instincts</strong> — if something feels wrong, end the ride</span></label>
       </div>
 
       <div class="confidence-check">
@@ -480,39 +481,39 @@
 
       <h2>📍 Uber &amp; Lyft Availability in Your Area</h2>
 
-      <table style="width:100%;border-collapse:collapse;margin:16px 0;font-size:0.9em;">
+      <table class="dcc-data-table dcc-data-table--filled dcc-data-table--center">
         <thead>
-          <tr style="background:var(--accent-primary);color:white;">
-            <th style="padding:10px;text-align:left;">City</th>
-            <th style="padding:10px;text-align:center;">Uber</th>
-            <th style="padding:10px;text-align:center;">Lyft</th>
+          <tr>
+            <th>City</th>
+            <th>Uber</th>
+            <th>Lyft</th>
           </tr>
         </thead>
         <tbody>
-          <tr style="border-bottom:1px solid var(--border-color);">
-            <td style="padding:10px;">Windsor</td>
-            <td style="padding:10px;text-align:center;">✅ Active</td>
-            <td style="padding:10px;text-align:center;">✅ Active</td>
-          </tr>
-          <tr style="border-bottom:1px solid var(--border-color);background:var(--bg-secondary);">
-            <td style="padding:10px;">London</td>
-            <td style="padding:10px;text-align:center;">✅ Active</td>
-            <td style="padding:10px;text-align:center;">✅ Active</td>
-          </tr>
-          <tr style="border-bottom:1px solid var(--border-color);">
-            <td style="padding:10px;">Kitchener-Waterloo</td>
-            <td style="padding:10px;text-align:center;">✅ Active</td>
-            <td style="padding:10px;text-align:center;">✅ Active</td>
-          </tr>
-          <tr style="border-bottom:1px solid var(--border-color);background:var(--bg-secondary);">
-            <td style="padding:10px;">St. Thomas</td>
-            <td style="padding:10px;text-align:center;">✅ Active</td>
-            <td style="padding:10px;text-align:center;">⚠️ Limited</td>
+          <tr>
+            <td>Windsor</td>
+            <td>✅ Active</td>
+            <td>✅ Active</td>
           </tr>
           <tr>
-            <td style="padding:10px;">Woodstock</td>
-            <td style="padding:10px;text-align:center;">✅ Active</td>
-            <td style="padding:10px;text-align:center;">⚠️ Limited</td>
+            <td>London</td>
+            <td>✅ Active</td>
+            <td>✅ Active</td>
+          </tr>
+          <tr>
+            <td>Kitchener-Waterloo</td>
+            <td>✅ Active</td>
+            <td>✅ Active</td>
+          </tr>
+          <tr>
+            <td>St. Thomas</td>
+            <td>✅ Active</td>
+            <td>⚠️ Limited</td>
+          </tr>
+          <tr>
+            <td>Woodstock</td>
+            <td>✅ Active</td>
+            <td>⚠️ Limited</td>
           </tr>
         </tbody>
       </table>
@@ -692,7 +693,7 @@
       </div>
 
       
-  <div style="text-align:center;padding:1rem 0 0.5rem">
+  <div class="dcc-print-row">
     <button class="btn-print" onclick="window.print()" aria-label="Print this module">🖨️ Print This Module</button>
   </div>
       <section class="related-modules" aria-label="Related modules">
@@ -723,7 +724,7 @@
         <a href="final-quiz.html" class="btn btn-primary btn-next">Take the Final Assessment →</a>
       </div>
 
-            <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+            <div class="dc-newsletter-slot"></div>
       <footer class="site-footer">
         <div class="footer-inner">
           <p class="footer-brand">Digital Confidence Centre</p>
@@ -806,7 +807,7 @@
           </div>
         </div>
       </div>
-      <div class="dcc-quiz-container" id="dcc-after-quiz" aria-label="Knowledge check — after the module" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz" aria-label="Knowledge check — after the module"></div>
       <div class="sources-block">
         <h3 data-en="Sources &amp; References" data-fr="Sources et références">Sources &amp; References</h3>
         <ul>

--- a/module-12.html
+++ b/module-12.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta property="og:url" content="https://twobirds-kramerica.github.io/digital-confidence/module-12.html">
@@ -364,7 +365,7 @@
 </head>
 <body>
   <noscript>
-    <div style="padding:20px;font-family:Georgia,serif;max-width:800px;margin:0 auto">
+    <div class="dcc-noscript">
       <h1>Digital Confidence Centre — Module 12: Getting the Help You Deserve</h1>
       <p>Free digital literacy training for seniors in Ontario.</p>
       <nav>
@@ -419,7 +420,7 @@
   <div class="page-wrapper">
     <main class="main-content" id="main">
 
-      <div class="dcc-quiz-container" id="dcc-before-quiz" aria-label="Knowledge check — before you start" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz" aria-label="Knowledge check — before you start"></div>
       <p class="module-category-label">Daily Life</p>
       <h1>Module 12: Getting the Help You Deserve</h1>
       <p><strong>What you will learn:</strong> How to escape automated phone systems, use scripts to slow down rushed service reps, manage well-meaning family helpers, and stay safe when someone offers remote access to your device.</p>
@@ -787,7 +788,7 @@
       <div class="warning-box">
         <span class="warning-box-label">🚨 Critical Warning — This Is a Very Common Scam</span>
         <p>Never allow remote access if someone <strong>called YOU unexpectedly</strong> — even if Caller ID shows Apple, Microsoft, your bank, or the Canada Revenue Agency. Caller ID can be faked. This is one of the most costly scams targeting seniors. Scammers may sound official, use real company names, and create genuine urgency. <strong>Hang up anyway.</strong> Call the real company back using the number on their official website.</p>
-        <p style="margin-top:0.75rem"><strong>They may also:</strong> Tell you your computer has a virus and they can see it. Claim your SIN has been compromised. Say your bank account is being drained. Demand you stay on the line while they "fix" it. Every single word is a lie designed to scare you into compliance.</p>
+        <p class="dcc-mt-3"><strong>They may also:</strong> Tell you your computer has a virus and they can see it. Claim your SIN has been compromised. Say your bank account is being drained. Demand you stay on the line while they "fix" it. Every single word is a lie designed to scare you into compliance.</p>
       </div>
 
       <div class="confidence-check-box">
@@ -862,7 +863,7 @@
       </div>
 
       
-  <div style="text-align:center;padding:1rem 0 0.5rem">
+  <div class="dcc-print-row">
     <button class="btn-print" onclick="window.print()" aria-label="Print this module">🖨️ Print This Module</button>
   </div>
       <section class="related-modules" aria-label="Related modules">
@@ -893,7 +894,7 @@
         <a href="index.html" class="btn btn-primary btn-next">Back to Home →</a>
       </div>
 
-      <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+      <div class="dc-newsletter-slot"></div>
       <footer class="site-footer">
         <div class="footer-inner">
           <p class="footer-brand">Digital Confidence Centre</p>
@@ -976,7 +977,7 @@
           </div>
         </div>
       </div>
-      <div class="dcc-quiz-container" id="dcc-after-quiz" aria-label="Knowledge check — after the module" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz" aria-label="Knowledge check — after the module"></div>
       <div class="sources-block">
         <h3 data-en="Sources &amp; References" data-fr="Sources et références">Sources &amp; References</h3>
         <ul>

--- a/module-13.html
+++ b/module-13.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta name="googlebot" content="index, follow">
@@ -181,9 +182,9 @@
 </head>
 <body>
   <noscript>
-    <div style="padding:20px;font-family:Georgia,serif;max-width:800px;margin:0 auto">
+    <div class="dcc-noscript">
       <h1>Digital Confidence Centre</h1>
-      <div class="dcc-quiz-container" id="dcc-before-quiz" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       <nav>
         <a href="index.html">Home</a> |
             <a href="digital-literacy-101.html">Modules</a> |
@@ -242,10 +243,10 @@
   <a href="#main" class="skip-link">Skip to main content</a>
 
   <div class="accessibility-bar" role="toolbar" aria-label="Accessibility controls">
-    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false" style="font-size:0.8rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true" style="font-size:1rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false" style="font-size:1.2rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false" style="font-size:1.4rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false">A</button>
+    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true">A</button>
+    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false">A</button>
+    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false">A</button>
     <button class="a11y-btn theme-toggle-btn" aria-label="Switch to dark mode">🌓</button>
   </div>
 
@@ -325,10 +326,10 @@
       <div class="sidebar-a11y-section">
         <p class="sidebar-a11y-title">Text Size</p>
         <div class="sidebar-font-row">
-          <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false" style="font-size:0.8rem">A</button>
-          <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="false" style="font-size:1rem">A</button>
-          <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false" style="font-size:1.2rem">A</button>
-          <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false" style="font-size:1.4rem">A</button>
+          <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false">A</button>
+          <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="false">A</button>
+          <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false">A</button>
+          <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false">A</button>
         </div>
         <p class="sidebar-a11y-title">Screen Colour</p>
         <div class="sidebar-theme-row">
@@ -818,7 +819,7 @@
       </div>
 
       
-  <div style="text-align:center;padding:1rem 0 0.5rem">
+  <div class="dcc-print-row">
     <button class="btn-print" onclick="window.print()" aria-label="Print this module">🖨️ Print This Module</button>
   </div>
       <section class="related-modules" aria-label="Related modules">
@@ -849,9 +850,9 @@
         <a href="module-14.html" class="btn btn-primary btn-next">Next: Smart Home Basics &#8594;</a>
       </div>
 
-      <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+      <div class="dc-newsletter-slot"></div>
 
-      <div class="dcc-quiz-container" id="dcc-after-quiz" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz"></div>
 
       <div class="connect-activity">
         <div class="connect-activity__header">

--- a/module-14.html
+++ b/module-14.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="Module 14: Smart Home Basics — Digital Confidence Centre">
@@ -351,9 +352,9 @@
 </head>
 <body>
   <noscript>
-    <div style="padding:20px;font-family:Georgia,serif;max-width:800px;margin:0 auto">
+    <div class="dcc-noscript">
       <h1>Digital Confidence Centre — Module 14: Smart Home Basics</h1>
-      <div class="dcc-quiz-container" id="dcc-before-quiz" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
 
       <div class="module-intro">
         <p class="module-time">&#9203; About 25–35 minutes — go at your own pace</p>
@@ -752,27 +753,27 @@
         <div class="privacy-row">
           <span class="privacy-device">🌡️ Smart Thermostat</span>
           <span class="privacy-level privacy-medium">Moderate</span>
-          <span style="font-size:0.82rem;color:var(--color-text-muted,#666)">Learns when you are home or away; energy usage patterns</span>
+          <span class="dcc-meta-note">Learns when you are home or away; energy usage patterns</span>
         </div>
         <div class="privacy-row">
           <span class="privacy-device">🔔 Video Doorbell</span>
           <span class="privacy-level privacy-high">Higher</span>
-          <span style="font-size:0.82rem;color:var(--color-text-muted,#666)">Video recordings of visitors; motion events; facial recognition (some models)</span>
+          <span class="dcc-meta-note">Video recordings of visitors; motion events; facial recognition (some models)</span>
         </div>
         <div class="privacy-row">
           <span class="privacy-device">🔊 Voice Assistant</span>
           <span class="privacy-level privacy-high">Higher</span>
-          <span style="font-size:0.82rem;color:var(--color-text-muted,#666)">Voice commands recorded after wake word; questions asked; connected device states</span>
+          <span class="dcc-meta-note">Voice commands recorded after wake word; questions asked; connected device states</span>
         </div>
         <div class="privacy-row">
           <span class="privacy-device">💡 Smart Lighting</span>
           <span class="privacy-level privacy-low">Lower</span>
-          <span style="font-size:0.82rem;color:var(--color-text-muted,#666)">When lights are on or off; schedules set</span>
+          <span class="dcc-meta-note">When lights are on or off; schedules set</span>
         </div>
         <div class="privacy-row">
           <span class="privacy-device">🔌 Smart Plug</span>
           <span class="privacy-level privacy-low">Lower</span>
-          <span style="font-size:0.82rem;color:var(--color-text-muted,#666)">When device is on or off; energy usage (on some models)</span>
+          <span class="dcc-meta-note">When device is on or off; energy usage (on some models)</span>
         </div>
       </div>
 
@@ -902,7 +903,7 @@
       </div>
 
       
-  <div style="text-align:center;padding:1rem 0 0.5rem">
+  <div class="dcc-print-row">
     <button class="btn-print" onclick="window.print()" aria-label="Print this module">🖨️ Print This Module</button>
   </div>
       <section class="related-modules" aria-label="Related modules">
@@ -933,7 +934,7 @@
         <a href="module-15.html" class="btn btn-primary btn-next">Next: Telehealth &amp; Medical Portals →</a>
       </div>
 
-      <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+      <div class="dc-newsletter-slot"></div>
       <footer class="site-footer">
         <div class="footer-inner">
           <p class="footer-brand">Digital Confidence Centre</p>
@@ -964,7 +965,7 @@
 
       <div id="progress-announcer" aria-live="polite" aria-atomic="true" class="sr-only"></div>
 
-      <div class="dcc-quiz-container" id="dcc-after-quiz" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz"></div>
     </main>
   </div>
   <script src="js/speech-config.js" defer></script>

--- a/module-15.html
+++ b/module-15.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="Module 15: Telehealth &amp; Medical Portals — Digital Confidence Centre">
@@ -317,9 +318,9 @@
 </head>
 <body>
   <noscript>
-    <div style="padding:20px;font-family:Georgia,serif;max-width:800px;margin:0 auto">
+    <div class="dcc-noscript">
       <h1>Digital Confidence Centre — Module 15: Telehealth &amp; Medical Portals</h1>
-      <div class="dcc-quiz-container" id="dcc-before-quiz" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       <p>Free digital literacy training for seniors in Ontario.</p>
       <nav>
         <a href="index.html">Home</a> |
@@ -911,7 +912,7 @@
       </div>
 
       
-  <div style="text-align:center;padding:1rem 0 0.5rem">
+  <div class="dcc-print-row">
     <button class="btn-print" onclick="window.print()" aria-label="Print this module">🖨️ Print This Module</button>
   </div>
       <section class="related-modules" aria-label="Related modules">
@@ -932,12 +933,12 @@
             <span class="related-name">Passwords &amp; Biometrics</span>
             <span class="related-desc">Your health portal contains sensitive personal information — protect it with a strong, unique password.</span>
           </a>
-          <a href="resources/dental-care-guide.html" class="related-card" style="border-top:3px solid var(--color-primary,#2A7B6F)">
+          <a href="resources/dental-care-guide.html" class="related-card dcc-top--brand">
             <span class="related-num">🦷 Guide</span>
             <span class="related-name">Canada Dental Care Plan</span>
             <span class="related-desc">If you have no private dental insurance and earn under $90,000, you may qualify for free dental care — enrol through My Service Canada Account.</span>
           </a>
-          <a href="resources/gis-guide.html" class="related-card" style="border-top:3px solid var(--color-primary,#2A7B6F)">
+          <a href="resources/gis-guide.html" class="related-card dcc-top--brand">
             <span class="related-num">💰 Guide</span>
             <span class="related-name">Guaranteed Income Supplement</span>
             <span class="related-desc">If your income is low, GIS provides up to $1,065/month extra on top of OAS — managed through the same Service Canada portal as many health benefits.</span>
@@ -952,7 +953,7 @@
         <a href="final-quiz.html" class="btn btn-primary btn-next">Next: Final Assessment →</a>
       </div>
 
-      <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+      <div class="dc-newsletter-slot"></div>
       <footer class="site-footer">
         <div class="footer-inner">
           <p class="footer-brand">Digital Confidence Centre</p>
@@ -983,7 +984,7 @@
 
       <div id="progress-announcer" aria-live="polite" aria-atomic="true" class="sr-only"></div>
 
-      <div class="dcc-quiz-container" id="dcc-after-quiz" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz"></div>
     </main>
   </div>
 

--- a/module-16-travel-safety.html
+++ b/module-16-travel-safety.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta name="googlebot" content="index, follow">
@@ -152,9 +153,9 @@
 </head>
 <body>
   <noscript>
-    <div style="padding:20px;font-family:Georgia,serif;max-width:800px;margin:0 auto">
+    <div class="dcc-noscript">
       <h1>Module 16: Staying Safe When You Travel</h1>
-      <div class="dcc-quiz-container" id="dcc-before-quiz" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       <p>Free digital literacy training for seniors in Ontario.</p>
       <nav>
         <a href="index.html">Home</a> |
@@ -539,11 +540,11 @@
         </ul>
       </div>
 
-      <div class="dcc-quiz-container" id="dcc-after-quiz" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz"></div>
     </main>
   </div>
 
-  <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+  <div class="dc-newsletter-slot"></div>
       <footer class="site-footer">
     <div class="footer-inner">
       <div class="footer-brand">Digital Confidence Centre</div>

--- a/module-17-ai-research.html
+++ b/module-17-ai-research.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta name="googlebot" content="index, follow">
@@ -151,7 +152,7 @@
 </head>
 <body>
   <noscript>
-    <div style="padding:20px;font-family:Georgia,serif;max-width:800px;margin:0 auto">
+    <div class="dcc-noscript">
       <h1>Module 17: Using AI for Research</h1>
       <p>Free digital literacy training for seniors in Ontario.</p>
       <nav>
@@ -464,7 +465,7 @@
     </main>
   </div>
 
-  <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+  <div class="dc-newsletter-slot"></div>
       <footer class="site-footer">
     <div class="footer-inner">
       <div class="footer-brand">Digital Confidence Centre</div>

--- a/module-18-staying-connected.html
+++ b/module-18-staying-connected.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta property="og:url" content="https://twobirds-kramerica.github.io/digital-confidence/module-18-staying-connected.html">
@@ -140,10 +141,10 @@
   <a href="#main" class="skip-link">Skip to main content</a>
 
   <div class="accessibility-bar" role="toolbar" aria-label="Accessibility controls">
-    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false" style="font-size:0.8rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true" style="font-size:1rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false" style="font-size:1.2rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false" style="font-size:1.4rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false">A</button>
+    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true">A</button>
+    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false">A</button>
+    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false">A</button>
     <button class="a11y-btn theme-toggle-btn" aria-label="Switch to dark mode">🌓</button>
   </div>
 
@@ -224,7 +225,7 @@
         <div class="module-number-badge">Module 18</div>
         <p class="module-category-label">Living Independently</p>
         <h1 data-en="Staying Connected When It Matters Most" data-fr="Rester en Contact Quand C'est Important">Staying Connected When It Matters Most</h1>
-      <div class="dcc-quiz-container" id="dcc-before-quiz" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>
 
       <div class="module-intro">
@@ -539,9 +540,9 @@
         <button class="mark-complete-btn" data-module="18" data-en="✅ Mark as complete" data-fr="✅ Marquer comme terminé">✅ Mark as complete</button>
       </div>
 
-      <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+      <div class="dc-newsletter-slot"></div>
 
-      <div class="dcc-quiz-container" id="dcc-after-quiz" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz"></div>
     </main>
   </div>
 

--- a/module-19-digital-legacy.html
+++ b/module-19-digital-legacy.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta property="og:url" content="https://twobirds-kramerica.github.io/digital-confidence/module-19-digital-legacy.html">
@@ -140,10 +141,10 @@
   <a href="#main" class="skip-link">Skip to main content</a>
 
   <div class="accessibility-bar" role="toolbar" aria-label="Accessibility controls">
-    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false" style="font-size:0.8rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true" style="font-size:1rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false" style="font-size:1.2rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false" style="font-size:1.4rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false">A</button>
+    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true">A</button>
+    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false">A</button>
+    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false">A</button>
     <button class="a11y-btn theme-toggle-btn" aria-label="Switch to dark mode">🌓</button>
   </div>
 
@@ -224,7 +225,7 @@
         <div class="module-number-badge">Module 19</div>
         <p class="module-category-label">Living Independently</p>
         <h1 data-en="Your Digital Life — Keeping It Safe and Organised" data-fr="Votre Vie Numérique — La Garder Sûre et Organisée">Your Digital Life — Keeping It Safe and Organised</h1>
-      <div class="dcc-quiz-container" id="dcc-before-quiz" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>
 
       <div class="module-intro">
@@ -510,9 +511,9 @@
         <button class="mark-complete-btn" data-module="19" data-en="✅ Mark as complete" data-fr="✅ Marquer comme terminé">✅ Mark as complete</button>
       </div>
 
-      <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+      <div class="dc-newsletter-slot"></div>
 
-      <div class="dcc-quiz-container" id="dcc-after-quiz" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz"></div>
     </main>
   </div>
 

--- a/module-20-internet-plan.html
+++ b/module-20-internet-plan.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="css/print.css" media="print">
   <link rel="stylesheet" href="css/quiz-check.css">
   <link rel="stylesheet" href="css/measurement.css">
+  <link rel="stylesheet" href="css/dcc-core.css">
   <meta name="author" content="Digital Confidence Centre">
   <meta name="robots" content="index, follow">
   <meta property="og:url" content="https://twobirds-kramerica.github.io/digital-confidence/module-20-internet-plan.html">
@@ -140,10 +141,10 @@
   <a href="#main" class="skip-link">Skip to main content</a>
 
   <div class="accessibility-bar" role="toolbar" aria-label="Accessibility controls">
-    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false" style="font-size:0.8rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true" style="font-size:1rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false" style="font-size:1.2rem">A</button>
-    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false" style="font-size:1.4rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false">A</button>
+    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true">A</button>
+    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false">A</button>
+    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false">A</button>
     <button class="a11y-btn theme-toggle-btn" aria-label="Switch to dark mode">🌓</button>
   </div>
 
@@ -224,7 +225,7 @@
         <div class="module-number-badge">Module 20</div>
         <p class="module-category-label">Living Independently</p>
         <h1 data-en="Understanding Your Internet Plan" data-fr="Comprendre votre forfait Internet">Understanding Your Internet Plan</h1>
-      <div class="dcc-quiz-container" id="dcc-before-quiz" style="margin-bottom:1.5rem"></div>
+      <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>
 
       <div class="module-intro">
@@ -429,7 +430,7 @@
         <div class="tip-box">
           <h3 data-en="🗣️ The Exact Words to Say" data-fr="🗣️ Les mots exacts à dire">🗣️ The Exact Words to Say</h3>
           <p data-en="When you get through to a representative, say something like this:" data-fr="Lorsque vous joignez un représentant, dites quelque chose comme ceci :">When you get through to a representative, say something like this:</p>
-          <p data-en="'I've been a loyal customer for [X] years. I've been looking at what's available, and I see that [competitor name] offers [speed] internet with unlimited data for [price] per month. I'd like to stay with you, but I need you to match that — or offer me something competitive. Can you help me with that?'" data-fr="« Je suis un client fidèle depuis [X] ans. J'ai regardé ce qui est disponible, et je vois que [nom du concurrent] offre Internet [vitesse] avec données illimitées pour [prix] par mois. J'aimerais rester avec vous, mais j'ai besoin que vous égaliez cette offre — ou que vous m'offriez quelque chose de compétitif. Pouvez-vous m'aider avec cela ? »" style="font-style: italic; background: #f0f7ff; padding: 1rem; border-radius: 8px; border-top: 4px solid #1565C0; display: block;">"I've been a loyal customer for [X] years. I've been looking at what's available, and I see that [competitor name] offers [speed] internet with unlimited data for [price] per month. I'd like to stay with you, but I need you to match that — or offer me something competitive. Can you help me with that?"</p>
+          <p class="dcc-callout dcc-callout--info" data-en="'I've been a loyal customer for [X] years. I've been looking at what's available, and I see that [competitor name] offers [speed] internet with unlimited data for [price] per month. I'd like to stay with you, but I need you to match that — or offer me something competitive. Can you help me with that?'" data-fr="« Je suis un client fidèle depuis [X] ans. J'ai regardé ce qui est disponible, et je vois que [nom du concurrent] offre Internet [vitesse] avec données illimitées pour [prix] par mois. J'aimerais rester avec vous, mais j'ai besoin que vous égaliez cette offre — ou que vous m'offriez quelque chose de compétitif. Pouvez-vous m'aider avec cela ? »">"I've been a loyal customer for [X] years. I've been looking at what's available, and I see that [competitor name] offers [speed] internet with unlimited data for [price] per month. I'd like to stay with you, but I need you to match that — or offer me something competitive. Can you help me with that?"</p>
         </div>
 
         <div class="tip-box">
@@ -616,9 +617,9 @@
         <button class="mark-complete-btn" data-module="20" data-en="✅ Mark as complete" data-fr="✅ Marquer comme terminé">✅ Mark as complete</button>
       </div>
 
-      <div class="dc-newsletter-slot" style="margin:2rem 0 1rem"></div>
+      <div class="dc-newsletter-slot"></div>
 
-      <div class="dcc-quiz-container" id="dcc-after-quiz" style="margin:2rem 0"></div>
+      <div class="dcc-quiz-container" id="dcc-after-quiz"></div>
     </main>
   </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Batch 2 of the Digital Confidence Centre design-system migration. Moves **modules 11–20** onto the shared token / `css/dcc-core.css` layer, following the exact pattern established and merged in batch 1 (modules 1–10).

Migrated pages:

- `module-11.html` — Ride-Sharing Apps
- `module-12.html` — Getting the Help You Deserve
- `module-13.html` — Understanding Social Media
- `module-14.html` — Smart Home Basics
- `module-15.html` — Telehealth & Medical Portals
- `module-16-travel-safety.html` — Staying Safe When You Travel
- `module-17-ai-research.html` — Using AI for Research
- `module-18-staying-connected.html` — Staying Connected When It Matters Most
- `module-19-digital-legacy.html` — Your Digital Life
- `module-20-internet-plan.html` — Understanding Your Internet Plan

## Changes

- **Load `css/dcc-core.css`** (last in the cascade) in each of the 10 module heads.
- **Removed presentational inline `style=` attributes** and replaced them with existing token-driven classes from batch 1: `.dcc-noscript`, `.dcc-print-row`, `.dcc-data-table` (+ `--filled`), `.dcc-top--brand`, `.dcc-mt-3`, and the `.font-size-btn[data-size]` sizing (so the A-/A/A+ glyphs scale via tokens, not inline `font-size`).
- **Added a small `7b` section to `dcc-core.css`** for three patterns not present in batch 1, all token-driven and AA-safe:
  - `.dcc-checklist` — preserves the flex-start, padded checklist layout (module-11) on top of the shared `.checklist` base.
  - `.dcc-data-table--center` — centres all but the first column of the availability table (module-11) without `!important`.
  - `.dcc-meta-note` — replaces off-token `#666` + sub-floor `0.82rem` privacy-meter notes (module-14) with the token colour and the 16px senior minimum.
- **Fixed off-token colours in module-20**: the "exact words to say" script box used inline `#f0f7ff` / `#1565C0` and `font-style: italic`. Re-pointed to the AA-safe `.dcc-callout dcc-callout--info` component (info-light background, info left border, left-aligned, non-italic per the accessibility bar).
- **Updated `AGENTS.md`** migration-status checklist to tick modules 11–20.

## What was deliberately skipped (and why)

- **Page-embedded `<style>` blocks** (still present on several pages, e.g. module-12/14/15) were left intact — batch 1 did the same (module-1 still carries its `<style>` blocks). These blocks already reference `var(--color-primary, …)`, so the off-token hex values (`#1565C0`) are **dead fallbacks**, not live colours; the live value is the brand token. Migrating full `<style>` blocks is a larger, higher-risk effort tracked as future work.
- **`lang/fr/modules/module-*.html`** French mirrors were not touched — also out of scope for batch 1, which only migrated the canonical English module files.
- **Functional `display:none`** inline styles (JS-toggled `.scenario-answer`, hidden `.city-footer-label` / `.device-footer-label`) were left in place, exactly as batch 1 did — these are behavioural state, not presentation.

## Constraints honoured

- Static only; no new dependencies, build step, or backend calls.
- No module learning content, links, or JS hooks changed (ids, `data-size`, `.dcc-quiz-container`, `[data-en]/[data-fr]`, footer-label hooks all preserved).
- No new colour tokens introduced, so the WCAG 2.2 AA contrast already verified in `tokens.css` still holds.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f82aa35-f10d-458b-82bb-1739818eec81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f82aa35-f10d-458b-82bb-1739818eec81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

