### PR TITLE
feat(dcc): batch-3 module migration + S-DCC-INTERACTION-FIX UX bugs

### DIFF
--- a/_audit/interaction-audit-2026-06-28.md
+++ b/_audit/interaction-audit-2026-06-28.md
@@ -1,0 +1,108 @@
+# S-DCC-INTERACTION-FIX — Interaction Audit
+**Date:** 2026-06-28 | **Viewports tested:** 375px, source audit  
+**Method:** Source-level audit + Playwright snapshot (375px viewport)
+
+---
+
+## Complaint 1 — Buttons overlapping
+
+**Files:** `js/app.js` (B4 section, line ~405), `js/feedback-github.js` (line ~135), `js/speech-config.js` (line ~325), `js/help-button.js` (line 26), `css/bundle.css` (`.dc-unified-feedback-btn`)
+
+**Root causes found:**
+
+| Element | File | Position | z-index |
+|---|---|---|---|
+| `dcc-help-btn` (teal `?` circle) | `js/app.js` B4 | `bottom:24px; right:20px` | 9990 |
+| `dc-unified-feedback-btn` (pill) | `feedback-github.js` + `bundle.css` | `bottom:80px; right:16px` | 200 |
+| Speech stop button | `js/speech-config.js` | `bottom:80px; right:16px` | 9998 |
+| `? Help` text button | `js/help-button.js` | `top:5rem; right:1rem` | 9000 |
+
+- `dc-unified-feedback-btn` and speech stop button sit at **exact same position** (bottom:80px, right:16px) — perfect overlap when reading aloud is active
+- `dcc-help-btn` (bottom:24px) is only 32px below `dc-unified-feedback-btn` (bottom:80px - 52px height) — visually adjacent/overlapping on small screens
+- Two separate help buttons (`? Help` top-right, `?` circle bottom-right) serve different functions but look like duplicates — confusing
+
+**Verdict:** `dcc-help-btn` in `app.js` B4 is the redundant element. `help-button.js` is the canonical help widget (it has About/Tech problem/Call for help options). The B4 teal circle should be **removed**. Speech stop button should move to `bottom:80px; right:88px` (left of feedback btn) or `top:5rem; right:1rem` range.
+
+---
+
+## Complaint 2 — Close buttons inconsistent
+
+**Files:** `module-1.html` (sidebar), `js/panic-button.js`, `js/feedback-github.js`
+
+| Element | Close button text |
+|---|---|
+| Sidebar (`.sidebar-close`) | `Close ✕` (data-en attribute) |
+| Scam modal | `× Close` (Unicode × + space + word) |
+| Feedback modal | `× Close` (same Unicode pattern) |
+| app.js helpSheet | `Close` (no symbol) |
+
+**AGENTS.md canonical format:** `✕ Close` — note: ✕ is U+2715 (✕), not × (U+00D7 multiplication sign).
+
+Scam modal and feedback modal both use `×` (multiplication sign ×) not `✕` (✕), and put the symbol BEFORE "Close" rather than after. Sidebar uses the correct format (`Close ✕`) via data attribute.
+
+**Fix:** Standardise all close buttons to `✕ Close` using `✕ Close`.
+
+---
+
+## Complaint 3 — Flyouts won't close / Escape broken
+
+**Files:** `js/app.js` (sidebar, B4 helpSheet), `js/help-button.js`, `js/panic-button.js`, `js/feedback-github.js`, `js/keyboard-helper.js`
+
+**Root causes:**
+
+1. **Sidebar null-crash risk**: `initSidebar()` registers `document.addEventListener('keydown', ...)` that accesses `sidebar.classList` — if `sidebar` is `null` (non-module pages) this throws `TypeError`, potentially silencing subsequent keydown handlers. Guard needed: `if (!sidebar) return;` before the keydown registration.
+
+2. **app.js B4 helpSheet no Escape handler**: The teal `?` circle's help sheet (app.js ~line 425) has outside-click dismiss but NO Escape key handler. Pressing Escape while the helpSheet is open does nothing — it fires the sidebar Escape handler instead (if sidebar is open) or does nothing.
+
+3. **Multiple competing Escape handlers on `document`**: Five separate `document.addEventListener('keydown')` handlers for Escape:
+   - `app.js` → sidebar
+   - `help-button.js` → help popover
+   - `panic-button.js` → scam modal
+   - `feedback-github.js` → feedback modal
+   - `keyboard-helper.js` → keyboard dialog
+   All fire simultaneously on Escape. Individual guards (check if modal is `display:none`) work correctly in isolation, but stacking order matters on slow connections where all are registered before first interaction.
+
+4. **`<details>` accordion groups in sidebar**: The sidebar nav uses native `<details class="snav-group">` elements. These don't emit custom events and `app.js` doesn't trap Escape for closing individual open `<details>`. Users pressing Escape while a sub-menu is expanded expect it to collapse — it doesn't; Escape closes the whole sidebar instead.
+
+---
+
+## Complaint 4 — Mobile/tablet sizing broken
+
+**Files:** `css/bundle.css`, `css/mobile.css`, `js/feedback-github.js`
+
+Checked `dc-unified-feedback-btn` at 375px: at `right:16px` with padding `13px 22px` and font-size `15px`, the "Ideas & Feedback" label is ~180px wide — fits within 375px viewport.
+
+The `.dc-fab-mobile-label` span (`Feedback`) is intended to replace the full label on mobile — but this requires CSS to `display:none` the full label and `display:inline` the mobile label. Need to verify the bundle.css has this breakpoint.
+
+**Known sizing issues (from sprint brief):**
+- Touch targets: teal `?` circle is 52×52px ✓ (WCAG 44px min)
+- `? Help` button padding `0.5rem 1rem` at 0.9rem font = ~38px height — FAILS WCAG 2.5.5 44px minimum
+- Sidebar navigation accordion summaries: need to check min-height
+
+**Check needed on sidebar mobile:** Sidebar at 375px viewport — does `.sidebar` have `width:100%` or does it overlap content without full-coverage?
+
+---
+
+## Complaint 5 — Not intuitive
+
+**Root causes:**
+
+1. **Two `?` help buttons**: `? Help` (top-right, links to About/Tech/Call) and teal `?` circle (bottom-right, shows "refresh or go Home") — seniors presented with two identical-looking `?` buttons that open different panels. This is the most significant UX issue.
+
+2. **`dc-unified-feedback-btn` "Ideas & Feedback"**: A senior encountering a technical problem would not know to click "Ideas & Feedback" for help. The function is mismatched to what seniors need.
+
+3. **Sidebar navigation `<summary>` elements**: Native `<details>` disclosure triangles are small and may not be visible enough to seniors. No explicit "expand/collapse" affordance.
+
+4. **`sidebar-close` button position**: "Close ✕" button at top of sidebar — correct per AGENTS.md. No issues here.
+
+---
+
+## Fix Priority
+
+| # | Complaint | Fix | File(s) |
+|---|---|---|---|
+| 1 | **REMOVE** `dcc-help-btn` teal circle (B4 section in app.js) | Remove entire B4 IIFE | `js/app.js` |
+| 2 | **MOVE** speech stop button right-offset so it doesn't overlap feedback btn | Change `right:16px` → `right:88px` | `js/speech-config.js` |
+| 3 | **Standardise** close buttons to `✕ Close` | Replace `× Close` with `✕ Close` | `js/panic-button.js`, `js/feedback-github.js` |
+| 4 | **Add null-guard** to `initSidebar()` keydown handler | `if (!sidebar) return;` | `js/app.js` |
+| 5 | **Fix `? Help` button touch target** | Add `min-height:44px` | `js/help-button.js` |

--- a/accessibility/shortcuts.html
+++ b/accessibility/shortcuts.html
@@ -78,7 +78,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/cra-scam-signs.html
+++ b/answers/cra-scam-signs.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/emergency-contacts-phone.html
+++ b/answers/emergency-contacts-phone.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-avoid-phone-scams.html
+++ b/answers/how-to-avoid-phone-scams.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-back-up-iphone.html
+++ b/answers/how-to-back-up-iphone.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-block-phone-number.html
+++ b/answers/how-to-block-phone-number.html
@@ -128,7 +128,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-book-telehealth.html
+++ b/answers/how-to-book-telehealth.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-create-strong-password.html
+++ b/answers/how-to-create-strong-password.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-find-safe-app.html
+++ b/answers/how-to-find-safe-app.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-make-strong-password.html
+++ b/answers/how-to-make-strong-password.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-manage-notifications.html
+++ b/answers/how-to-manage-notifications.html
@@ -128,7 +128,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-pay-safely-online.html
+++ b/answers/how-to-pay-safely-online.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-protect-credit-card-online.html
+++ b/answers/how-to-protect-credit-card-online.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-recognise-fake-website.html
+++ b/answers/how-to-recognise-fake-website.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-recognise-romance-scam.html
+++ b/answers/how-to-recognise-romance-scam.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-share-photos-family.html
+++ b/answers/how-to-share-photos-family.html
@@ -128,7 +128,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-shop-safely-online.html
+++ b/answers/how-to-shop-safely-online.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-spot-email-scam.html
+++ b/answers/how-to-spot-email-scam.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-spot-fake-website.html
+++ b/answers/how-to-spot-fake-website.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-spot-phone-scam.html
+++ b/answers/how-to-spot-phone-scam.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-stay-safe-social-media.html
+++ b/answers/how-to-stay-safe-social-media.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-update-apps-ipad.html
+++ b/answers/how-to-update-apps-ipad.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-update-apps.html
+++ b/answers/how-to-update-apps.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-update-ipad.html
+++ b/answers/how-to-update-ipad.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-use-etransfer-safely.html
+++ b/answers/how-to-use-etransfer-safely.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-use-facetime.html
+++ b/answers/how-to-use-facetime.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-use-health-portal.html
+++ b/answers/how-to-use-health-portal.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-use-ride-sharing-safely.html
+++ b/answers/how-to-use-ride-sharing-safely.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-use-siri.html
+++ b/answers/how-to-use-siri.html
@@ -128,7 +128,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-use-wifi-safely.html
+++ b/answers/how-to-use-wifi-safely.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-video-call-family.html
+++ b/answers/how-to-video-call-family.html
@@ -128,7 +128,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/how-to-video-call-grandchildren.html
+++ b/answers/how-to-video-call-grandchildren.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/icloud-backup.html
+++ b/answers/icloud-backup.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/index.html
+++ b/answers/index.html
@@ -104,7 +104,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/is-it-safe-to-shop-online.html
+++ b/answers/is-it-safe-to-shop-online.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/is-public-wifi-safe.html
+++ b/answers/is-public-wifi-safe.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/is-this-email-safe.html
+++ b/answers/is-this-email-safe.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/is-zoom-safe.html
+++ b/answers/is-zoom-safe.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/online-banking-safely.html
+++ b/answers/online-banking-safely.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-is-a-qr-code.html
+++ b/answers/what-is-a-qr-code.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-is-ai-assistant.html
+++ b/answers/what-is-ai-assistant.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-is-phishing.html
+++ b/answers/what-is-phishing.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-is-smart-home-device.html
+++ b/answers/what-is-smart-home-device.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-is-spam-email.html
+++ b/answers/what-is-spam-email.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-is-strong-password.html
+++ b/answers/what-is-strong-password.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-is-two-factor-authentication.html
+++ b/answers/what-is-two-factor-authentication.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-is-vpn.html
+++ b/answers/what-is-vpn.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-to-do-if-scammed.html
+++ b/answers/what-to-do-if-scammed.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/answers/what-to-do-suspicious-text.html
+++ b/answers/what-to-do-suspicious-text.html
@@ -130,7 +130,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/b2b/case-study-template.html
+++ b/b2b/case-study-template.html
@@ -243,7 +243,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/b2b/index.html
+++ b/b2b/index.html
@@ -364,7 +364,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/b2b/pricing.html
+++ b/b2b/pricing.html
@@ -255,7 +255,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/b2b/roi-calculator.html
+++ b/b2b/roi-calculator.html
@@ -269,7 +269,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/beta/beta-confirmation.html
+++ b/beta/beta-confirmation.html
@@ -193,7 +193,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/beta/beta-guide.html
+++ b/beta/beta-guide.html
@@ -206,7 +206,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/beta/beta-landing.html
+++ b/beta/beta-landing.html
@@ -287,7 +287,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/beta/beta-survey.html
+++ b/beta/beta-survey.html
@@ -266,7 +266,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/exercises/email-sorting.html
+++ b/exercises/email-sorting.html
@@ -168,7 +168,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/exercises/password-strength.html
+++ b/exercises/password-strength.html
@@ -126,7 +126,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/exercises/scam-detective.html
+++ b/exercises/scam-detective.html
@@ -163,7 +163,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/family-setup.html
+++ b/family-setup.html
@@ -191,7 +191,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
         <a href="module-ai-literacy.html"><span class="nav-icon" aria-hidden="true">🧠</span><span class="nav-label">AI Literacy</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>
@@ -723,10 +723,10 @@
 
         <div class="mg-section">
           <details data-cat="independent">
-            <summary class="mg-section-summary" aria-label="Living Independently">
+            <summary class="mg-section-summary" aria-label="Staying Independent">
               <span class="mg-section-summary-icon" aria-hidden="true">🌟</span>
               <span class="mg-section-summary-text">
-                <span class="mg-section-summary-title">Living Independently</span>
+                <span class="mg-section-summary-title">Staying Independent</span>
                 <span class="mg-section-summary-desc">Travel safety, managing your bills, and taking charge of your digital world.</span>
               </span>
               <span class="mg-section-count">15 modules</span>

--- a/institutional.html
+++ b/institutional.html
@@ -451,10 +451,10 @@
   <!-- Eligibility -->
   <section class="section" aria-labelledby="eligibility-heading">
     <h2 id="eligibility-heading">NHSP eligibility quick check</h2>
-    <p class="section-sub">The New Horizons for Seniors Program (Employment and Social Development Canada) funds community-based projects up to CA$25,000. DCC fits the programme criteria directly.</p>
+    <p class="section-sub">The New Horizons for Seniors Program (Employment and Social Development Canada) funds community-based projects up to CA$50,000 for the 2026-27 cycle. DCC fits the programme criteria directly.</p>
 
     <div class="alert" role="note">
-      <p><strong>Deadline:</strong> NHSP typically runs two intakes per year — spring and fall. Verify the current intake dates at <a href="https://www.canada.ca/en/employment-social-development/services/new-horizons-seniors.html" target="_blank" rel="noopener noreferrer">canada.ca</a> before starting your application.</p>
+      <p><strong>2026-27 deadline: July 14, 2026.</strong> Applications must be submitted through <a href="https://www.canada.ca/en/employment-social-development/services/new-horizons-seniors.html" target="_blank" rel="noopener noreferrer">canada.ca</a>. Contact Two Birds Innovation before July 7 to allow one week for co-application support before the cutoff.</p>
     </div>
 
     <table class="eligibility-table" aria-label="NHSP eligibility criteria for DCC projects">
@@ -467,7 +467,7 @@
       <tbody>
         <tr>
           <td>Non-profit or eligible organization applying</td>
-          <td><span class="check">&#10003;</span> Libraries, senior centres, settlement agencies are all eligible applicants<span class="note">For-profit organizations may apply with restrictions — confirm eligibility with ESDC</span></td>
+          <td><span class="check">&#10003;</span> Libraries, seniors centres, settlement agencies, and municipal organisations are all eligible applicants<span class="note">For-profit organisations (like Two Birds Innovation) cannot be the lead applicant — they may participate as a delivery partner. The non-profit or community organisation holds the grant.</span></td>
         </tr>
         <tr>
           <td>Project benefits seniors (55+)</td>
@@ -553,10 +553,11 @@
 
   <!-- Budget -->
   <section class="section" aria-labelledby="budget-heading">
-    <h2 id="budget-heading">Sample budget</h2>
-    <p class="section-sub">This is a sample 12-month budget for a library or senior centre with an existing facilitator. Adjust based on your organisation's staff capacity and existing resources.</p>
+    <h2 id="budget-heading">Sample budgets</h2>
+    <p class="section-sub">Two budget models below: a lean pilot (~$13,000) and a full-scale seniors-centre deployment using the full $50,000 NHSP envelope. Adjust based on your organisation's staff capacity and existing resources.</p>
 
-    <table class="budget-table" aria-label="Sample NHSP project budget">
+    <h3 style="margin-bottom:8px;margin-top:0;">Option A — Lean pilot (library / small community org)</h3>
+    <table class="budget-table" aria-label="Sample lean NHSP project budget">
       <thead>
         <tr>
           <th scope="col">Budget Item</th>
@@ -602,7 +603,56 @@
         </tr>
       </tbody>
     </table>
-    <p class="budget-note">Note: NHSP community projects fund up to CA$25,000. This budget leaves room for in-kind contributions or additional cohort sessions without exceeding the limit. Two Birds Innovation can provide a formal licence invoice for grant reporting.</p>
+
+    <h3 style="margin-bottom:8px;margin-top:28px;">Option B — Full-scale deployment (seniors centre, $50,000 envelope)</h3>
+    <p style="font-size:15px;color:#475569;margin-bottom:16px;">Two 20-person cohorts over Year 1 (40 seniors). Two Seniors Centre staff trained as facilitators. Two Birds Innovation writes the application and provides delivery support.</p>
+    <table class="budget-table" aria-label="Sample full-scale NHSP seniors centre budget">
+      <thead>
+        <tr>
+          <th scope="col">Budget Item</th>
+          <th scope="col">Justification</th>
+          <th scope="col">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Facilitator training and programme coordination</td>
+          <td>Two Seniors Centre staff trained as DCC facilitators; ongoing coordination and administration across two 8-week cohorts</td>
+          <td>CA$15,000</td>
+        </tr>
+        <tr>
+          <td>Materials, devices, and equipment support</td>
+          <td>Tablets or laptop loans for participants without personal devices; print handouts; session supplies</td>
+          <td>CA$10,000</td>
+        </tr>
+        <tr>
+          <td>Community outreach and participant recruitment</td>
+          <td>Posters, local press, partner referrals, senior advisory panel coordination</td>
+          <td>CA$8,000</td>
+        </tr>
+        <tr>
+          <td>Accessibility accommodations</td>
+          <td>Large-print materials, assistive technology support, transportation assistance for participants</td>
+          <td>CA$7,000</td>
+        </tr>
+        <tr>
+          <td>Programme evaluation and reporting</td>
+          <td>Pre/post confidence surveys, module completion tracking, final impact report to Service Canada</td>
+          <td>CA$5,000</td>
+        </tr>
+        <tr>
+          <td>Contracted delivery support (Two Birds Innovation)</td>
+          <td>DCC curriculum licence, application writing, staff training delivery, ongoing facilitator support</td>
+          <td>CA$5,000</td>
+        </tr>
+        <tr>
+          <td><strong>Total</strong></td>
+          <td></td>
+          <td><strong>CA$50,000</strong></td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="budget-note">Budget is indicative. Final figures confirmed during co-application working session with Two Birds Innovation. The 2026-27 NHSP cycle maximum is CA$50,000 per application. Seniors centres with a mandate primarily focused on seniors receive priority scoring under 2026-27 criteria.</p>
   </section>
 
   <!-- Partnership letters -->

--- a/js/app.js
+++ b/js/app.js
@@ -92,6 +92,7 @@ function initSidebar() {
     overlay.addEventListener('click', closeSidebar);
   }
 
+  if (!sidebar) return;
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape' && sidebar.classList.contains('open')) {
       closeSidebar();
@@ -390,56 +391,6 @@ document.addEventListener('click', function (e) {
   });
 })();
 
-/* ============================================
-   B4: Help button — bottom-right circle
-   ============================================ */
-(function() {
-  document.addEventListener('DOMContentLoaded', function() {
-    var isFr = (localStorage.getItem('dc-lang') || 'en').startsWith('fr');
-
-    /* Help circle button */
-    var helpBtn = document.createElement('button');
-    helpBtn.id = 'dcc-help-btn';
-    helpBtn.setAttribute('aria-label', isFr ? 'Aide' : 'Help');
-    helpBtn.textContent = '?';
-    helpBtn.style.cssText = 'position:fixed;bottom:24px;right:20px;width:52px;height:52px;border-radius:50%;background:#2EC4B6;color:#fff;border:none;font-size:24px;font-weight:700;cursor:pointer;z-index:9990;box-shadow:0 2px 8px rgba(0,0,0,0.2);display:flex;align-items:center;justify-content:center;';
-
-    /* Help sheet */
-    var helpSheet = document.createElement('div');
-    helpSheet.id = 'dcc-help-sheet';
-    helpSheet.setAttribute('role', 'dialog');
-    helpSheet.setAttribute('aria-label', isFr ? 'Aide' : 'Help');
-    helpSheet.style.cssText = 'display:none;position:fixed;bottom:84px;right:20px;background:#fff;border-radius:12px;padding:20px;max-width:280px;box-shadow:0 4px 20px rgba(0,0,0,0.2);z-index:9991;';
-    helpSheet.innerHTML =
-      '<p style="font-weight:600;margin-bottom:8px;color:#1B3A4B;" data-en="Need help?" data-fr="Besoin d\'aide ?">' + (isFr ? "Besoin d'aide ?" : 'Need help?') + '</p>' +
-      '<p style="font-size:14px;color:#4A5568;margin-bottom:12px;" data-en="Try refreshing the page, or tap Home to start over." data-fr="Essayez de rafra\u00eechir la page, ou tapez Accueil pour recommencer.">' +
-        (isFr ? "Essayez de rafra\u00eechir la page, ou tapez " : 'Try refreshing the page, or tap ') +
-        '<a href="/digital-confidence/index.html" style="color:#2EC4B6;font-weight:600;">' + (isFr ? 'Accueil' : 'Home') + '</a>' +
-        (isFr ? ' pour recommencer.' : ' to start over.') +
-      '</p>' +
-      '<button style="background:#f0f0f0;border:none;border-radius:6px;padding:8px 16px;cursor:pointer;font-size:14px;min-height:44px;width:100%;" data-en="Close" data-fr="Fermer">' + (isFr ? 'Fermer' : 'Close') + '</button>';
-
-    document.body.appendChild(helpBtn);
-    document.body.appendChild(helpSheet);
-
-    helpBtn.addEventListener('click', function() {
-      helpSheet.style.display = helpSheet.style.display === 'none' ? 'block' : 'none';
-    });
-    helpSheet.querySelector('button').addEventListener('click', function() {
-      helpSheet.style.display = 'none';
-    });
-    document.addEventListener('click', function(e) {
-      if (!helpSheet.contains(e.target) && e.target !== helpBtn) {
-        helpSheet.style.display = 'none';
-      }
-    });
-
-    /* Dark mode styles */
-    var style = document.createElement('style');
-    style.textContent = '[data-theme="dark"] #dcc-help-sheet { background: #333; } [data-theme="dark"] #dcc-help-sheet p { color: #E8E8E8; } [data-theme="dark"] #dcc-help-sheet button { background: #444; color: #E8E8E8; }';
-    document.head.appendChild(style);
-  });
-})();
 
 /* ============================================
    B7: Kids cross-links — "Also for young learners" callout on parallel adult modules

--- a/js/feedback-github.js
+++ b/js/feedback-github.js
@@ -171,7 +171,7 @@ function injectFeedbackModal() {
       '<div class="dc-modal-content" role="document">',
 
         /* Clean text close button (not red circle) */
-        '<button class="dc-modal-close" id="dc-modal-close" aria-label="Close feedback">\u00d7 Close</button>',
+        '<button class="dc-modal-close" id="dc-modal-close" aria-label="Close feedback">Close ✕</button>',
 
         '<div id="dc-modal-form-area">',
         '<h2 class="dc-modal-title" id="dc-modal-title">Ideas &amp; Feedback 💬</h2>',

--- a/js/help-button.js
+++ b/js/help-button.js
@@ -47,6 +47,7 @@
       'font-size:0.9rem',
       'font-weight:700',
       'cursor:pointer',
+      'min-height:44px',
       'box-shadow:0 3px 10px rgba(0,0,0,0.25)',
       'font-family:inherit',
       'white-space:nowrap'

--- a/js/panic-button.js
+++ b/js/panic-button.js
@@ -34,7 +34,7 @@ function injectScamModal() {
     '<div id="dc-scam-modal" class="dc-scam-modal" role="dialog" aria-modal="true" aria-label="Scam help guide" style="display:none;">',
       '<div class="dc-scam-backdrop" id="dc-scam-backdrop"></div>',
       '<div class="dc-scam-content">',
-        '<button class="dc-scam-close" onclick="closeScamModal()" aria-label="Close scam guide">\u00d7 Close</button>',
+        '<button class="dc-scam-close" onclick="closeScamModal()" aria-label="Close scam guide">Close ✕</button>',
 
         '<h2 class="dc-scam-title">🚨 You\'re Safe Now — Here\'s What To Do</h2>',
 

--- a/js/speech-config.js
+++ b/js/speech-config.js
@@ -322,7 +322,7 @@ document.addEventListener('DOMContentLoaded', function() {
   var stopBtn = document.createElement('button');
   stopBtn.id = 'stop-reading-btn';
   stopBtn.textContent = isFr ? '\u23F9 Arrêter la lecture' : '\u23F9 Stop reading';
-  stopBtn.style.cssText = 'display:none;position:fixed;bottom:80px;right:16px;z-index:9998;background:#E74C3C;color:#fff;border:none;border-radius:24px;padding:10px 18px;font-size:14px;cursor:pointer;min-height:44px;box-shadow:0 2px 8px rgba(0,0,0,0.3);';
+  stopBtn.style.cssText = 'display:none;position:fixed;bottom:80px;right:88px;z-index:9998;background:#E74C3C;color:#fff;border:none;border-radius:24px;padding:10px 18px;font-size:14px;cursor:pointer;min-height:44px;box-shadow:0 2px 8px rgba(0,0,0,0.3);';
   document.body.appendChild(stopBtn);
   stopBtn.addEventListener('click', function() {
     window.speechSynthesis.cancel();

--- a/module-1.html
+++ b/module-1.html
@@ -362,7 +362,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-13.html
+++ b/module-13.html
@@ -299,7 +299,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-16-travel-safety.html
+++ b/module-16-travel-safety.html
@@ -209,7 +209,7 @@
   <div class="page-wrapper">
     <main class="main-content" id="main">
 
-      <p class="module-category-label">Living Independently</p>
+      <p class="module-category-label">Staying Independent</p>
       <h1 data-en="Module 16: Staying Safe When You Travel" data-fr="Module 16 : Rester en sécurité lors de vos voyages">Module 16: Staying Safe When You Travel</h1>
       <p class="what-you-learn"><strong data-en="What you will learn:" data-fr="Ce que vous apprendrez :">What you will learn:</strong> <span data-en="How to prepare your devices before a trip, use public Wi-Fi safely, avoid travel scams, protect yourself at airports, and know exactly who to call if something goes wrong — at home or abroad." data-fr="Comment préparer vos appareils avant un voyage, utiliser le Wi-Fi public en toute sécurité, éviter les arnaques de voyage, vous protéger dans les aéroports et savoir qui appeler si quelque chose tourne mal — au Canada ou à l'étranger.">How to prepare your devices before a trip, use public Wi-Fi safely, avoid travel scams, protect yourself at airports, and know exactly who to call if something goes wrong — at home or abroad.</span></p>
 

--- a/module-17-ai-research.html
+++ b/module-17-ai-research.html
@@ -207,7 +207,7 @@
   <div class="page-wrapper">
     <main class="main-content" id="main">
 
-      <p class="module-category-label">Living Independently</p>
+      <p class="module-category-label">Staying Independent</p>
       <h1 data-en="Module 17: Using AI for Research" data-fr="Module 17 : Utiliser l'IA pour faire des recherches">Module 17: Using AI for Research</h1>
       <p class="what-you-learn"><strong data-en="What you will learn:" data-fr="Ce que vous apprendrez :">What you will learn:</strong> <span data-en="How to use AI tools like Siri, ChatGPT, and Google Gemini to find information, ask better questions, check whether answers are accurate, protect your privacy, and know when to call a professional instead." data-fr="Comment utiliser des outils d'IA comme Siri, ChatGPT et Google Gemini pour trouver des informations, poser de meilleures questions, vérifier l'exactitude des réponses, protéger votre vie privée et savoir quand appeler un professionnel à la place.">How to use AI tools like Siri, ChatGPT, and Google Gemini to find information, ask better questions, check whether answers are accurate, protect your privacy, and know when to call a professional instead.</span></p>
 

--- a/module-18-staying-connected.html
+++ b/module-18-staying-connected.html
@@ -223,7 +223,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 18</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="Staying Connected When It Matters Most" data-fr="Rester en Contact Quand C'est Important">Staying Connected When It Matters Most</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-19-digital-legacy.html
+++ b/module-19-digital-legacy.html
@@ -223,7 +223,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 19</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="Your Digital Life — Keeping It Safe and Organised" data-fr="Votre Vie Numérique — La Garder Sûre et Organisée">Your Digital Life — Keeping It Safe and Organised</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-2-5.html
+++ b/module-2-5.html
@@ -305,7 +305,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-2.html
+++ b/module-2.html
@@ -360,7 +360,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-20-internet-plan.html
+++ b/module-20-internet-plan.html
@@ -223,7 +223,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 20</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="Understanding Your Internet Plan" data-fr="Comprendre votre forfait Internet">Understanding Your Internet Plan</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-21-mobile-plan.html
+++ b/module-21-mobile-plan.html
@@ -223,7 +223,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 21</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="Understanding Your Mobile Plan" data-fr="Comprendre Votre Forfait Mobile">Understanding Your Mobile Plan</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-22-tv-home-phone.html
+++ b/module-22-tv-home-phone.html
@@ -191,7 +191,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 22</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="TV and Home Phone — Cut the Costs, Keep What Matters" data-fr="Télévision et Téléphone Résidentiel — Réduisez les Coûts, Gardez l'Essentiel">TV and Home Phone — Cut the Costs, Keep What Matters</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz" aria-label="Knowledge check — before you start"></div>
       </div>

--- a/module-23-online-marketplace.html
+++ b/module-23-online-marketplace.html
@@ -223,7 +223,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 23</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="Buying and Selling Online Safely" data-fr="Acheter et vendre en ligne en toute sécurité">Buying and Selling Online Safely</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-24-communication.html
+++ b/module-24-communication.html
@@ -223,7 +223,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 24</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="Staying in Touch — Communication Apps and Tools" data-fr="Rester en contact — Applications et outils de communication">Staying in Touch — Communication Apps and Tools</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-25-outage-detection.html
+++ b/module-25-outage-detection.html
@@ -223,7 +223,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 25</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="When Things Stop Working" data-fr="Quand les choses cessent de fonctionner">When Things Stop Working</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-26-notifications.html
+++ b/module-26-notifications.html
@@ -223,7 +223,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 26</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="Managing Your Notifications" data-fr="Gérer vos notifications">Managing Your Notifications</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-27-inbox-spam.html
+++ b/module-27-inbox-spam.html
@@ -205,7 +205,7 @@
 
       <div class="module-header">
         <div class="module-number-badge">Module 27</div>
-        <p class="module-category-label">Living Independently</p>
+        <p class="module-category-label">Staying Independent</p>
         <h1 data-en="Your Inbox — Managing Email and Spam" data-fr="Votre boîte de réception — Gérer les courriels et le pourriel">Your Inbox — Managing Email and Spam</h1>
       <div class="dcc-quiz-container" id="dcc-before-quiz"></div>
       </div>

--- a/module-3.html
+++ b/module-3.html
@@ -362,7 +362,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-4.html
+++ b/module-4.html
@@ -354,7 +354,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-5.html
+++ b/module-5.html
@@ -352,7 +352,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-6.html
+++ b/module-6.html
@@ -354,7 +354,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-7.html
+++ b/module-7.html
@@ -353,7 +353,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-8.html
+++ b/module-8.html
@@ -353,7 +353,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-9.html
+++ b/module-9.html
@@ -354,7 +354,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-pressure-youth.html
+++ b/module-pressure-youth.html
@@ -1,0 +1,622 @@
+<!DOCTYPE html>
+<html lang="en-CA" data-font-size="medium">
+<head>
+  <meta charset="UTF-8">
+  <script>(function(){var t=localStorage.getItem('dc-theme');if(!t){t=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}document.documentElement.setAttribute('data-theme',t);})();</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="The Pressure You Can Name — interactive digital literacy for Canadian youth ages 12–18. Recognize guilt trips, group pile-ons, streak mechanics, and conditional friendship — and choose your own response.">
+  <meta name="keywords" content="peer pressure teens Canada, social manipulation youth, guilt trip online, Snapchat streak pressure, digital literacy 12-18 Canada, online social coercion">
+  <meta property="og:title" content="The Pressure You Can Name — Youth Social Literacy · Digital Confidence Centre">
+  <meta property="og:description" content="Guilt trips, group pile-ons, streak mechanics, and 'if you were really my friend' — four real scenarios about social pressure. When you can name the tactic, you can choose your response.">
+  <meta property="og:type" content="website">
+  <link rel="canonical" href="https://twobirds-kramerica.github.io/digital-confidence/module-pressure-youth.html">
+  <title>The Pressure You Can Name — Youth Social Literacy · Digital Confidence Centre</title>
+  <link rel="preload" href="fonts/merriweather/merriweather-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="fonts/merriweather/merriweather-700.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="css/bundle.css">
+  <link rel="stylesheet" href="css/mobile.css">
+  <link rel="stylesheet" href="css/print.css" media="print">
+  <link rel="stylesheet" href="css/quiz-check.css">
+  <link rel="stylesheet" href="css/measurement.css">
+  <meta name="author" content="Digital Confidence Centre">
+  <meta name="robots" content="index, follow">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#2A7B6F">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
+  <style>
+    /* Youth module colour overrides — violet/social palette */
+    :root {
+      --youth-violet:     #5C3D8F;
+      --youth-violet-bg:  #EDE8F5;
+      --youth-teal:       #00897B;
+      --youth-teal-bg:    #E0F2F1;
+      --youth-green:      #2E7D32;
+      --youth-green-bg:   #E8F5E9;
+      --youth-red:        #C62828;
+      --youth-red-bg:     #FFEBEE;
+    }
+
+    .youth-hero {
+      background: linear-gradient(135deg, #1a0a30 0%, #3d1f7a 100%);
+      color: #fff;
+      padding: 2.5rem 0 2rem;
+      text-align: center;
+      margin: -1.5rem -1.5rem 2rem;
+      border-radius: 0 0 16px 16px;
+    }
+    .youth-hero .eyebrow {
+      display: inline-block;
+      background: rgba(255,255,255,0.15);
+      border: 1px solid rgba(255,255,255,0.3);
+      border-radius: 20px;
+      padding: 0.25rem 0.9rem;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+      margin-bottom: 0.75rem;
+    }
+    .youth-hero h1 {
+      font-size: clamp(1.6rem, 4vw, 2.4rem);
+      font-weight: 800;
+      line-height: 1.15;
+      margin-bottom: 0.75rem;
+    }
+    .youth-hero p { font-size: 1rem; opacity: 0.85; max-width: 520px; margin: 0 auto; line-height: 1.55; }
+
+    /* Progress bar */
+    .scenario-progress {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .progress-pip {
+      width: 32px; height: 6px; border-radius: 3px;
+      background: var(--youth-violet-bg);
+      transition: background 0.25s;
+    }
+    .progress-pip.done { background: var(--youth-violet); }
+    .progress-pip.active { background: var(--youth-teal); }
+    .progress-label { font-size: 0.8rem; color: var(--color-text-light,#7A6E62); font-weight: 600; }
+
+    /* Scenario card */
+    .scenario-card {
+      background: var(--color-surface,#fff);
+      border: 2px solid var(--youth-violet-bg);
+      border-radius: 16px;
+      overflow: hidden;
+      margin-bottom: 2rem;
+      display: none;
+    }
+    .scenario-card.active { display: block; }
+
+    .scenario-header {
+      background: var(--youth-violet-bg);
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .scenario-num {
+      background: var(--youth-violet);
+      color: #fff;
+      width: 2rem; height: 2rem;
+      border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.85rem; font-weight: 800; flex-shrink: 0;
+    }
+    .scenario-tag { font-size: 0.78rem; font-weight: 700; color: var(--youth-violet); text-transform: uppercase; letter-spacing: 0.06em; }
+
+    .scenario-body { padding: 1.5rem; }
+    .scenario-title { font-size: 1.1rem; font-weight: 700; color: var(--color-text,#3D3229); margin-bottom: 0.75rem; }
+    .scenario-story {
+      font-size: 0.95rem;
+      line-height: 1.7;
+      color: #333;
+      margin-bottom: 1.25rem;
+      padding: 1rem 1.25rem;
+      background: #fafaf8;
+      border-top: 4px solid var(--youth-violet);
+      border-radius: 10px;
+    }
+    .scenario-question { font-size: 1rem; font-weight: 700; margin-bottom: 0.75rem; }
+
+    /* Answer options */
+    .answer-options { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1.25rem; }
+    .answer-btn {
+      display: flex; align-items: flex-start; gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      border: 2px solid var(--color-divider,#e0e0e0);
+      border-radius: 10px;
+      background: var(--color-surface,#fff);
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.9rem;
+      text-align: left;
+      color: var(--color-text,#3D3229);
+      transition: all 0.15s;
+      width: 100%;
+    }
+    .answer-btn:hover:not(:disabled) { border-color: var(--youth-violet); background: var(--youth-violet-bg); }
+    .answer-btn .ans-letter {
+      flex-shrink: 0; width: 1.5rem; height: 1.5rem;
+      background: var(--youth-violet-bg);
+      color: var(--youth-violet);
+      border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.75rem; font-weight: 700;
+      margin-top: 1px;
+    }
+    .answer-btn.selected-correct {
+      border-color: var(--youth-green);
+      background: var(--youth-green-bg);
+    }
+    .answer-btn.selected-correct .ans-letter { background: var(--youth-green); color: #fff; }
+    .answer-btn.selected-wrong {
+      border-color: var(--youth-red);
+      background: var(--youth-red-bg);
+    }
+    .answer-btn.selected-wrong .ans-letter { background: var(--youth-red); color: #fff; }
+    .answer-btn.reveal-correct {
+      border-color: var(--youth-green);
+      background: var(--youth-green-bg);
+      opacity: 0.7;
+    }
+    .answer-btn:disabled { cursor: default; }
+
+    /* Debrief */
+    .scenario-debrief {
+      display: none;
+      margin-top: 1rem;
+      padding: 1rem 1.25rem;
+      border-radius: 10px;
+      border-top: 4px solid var(--youth-teal);
+      background: var(--youth-teal-bg);
+    }
+    .scenario-debrief.visible { display: block; }
+    .debrief-label { font-size: 0.75rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.07em; color: var(--youth-teal); margin-bottom: 0.4rem; }
+    .scenario-debrief p { font-size: 1rem; line-height: 1.6; color: #1a3a38; }
+
+    .btn-next-scenario {
+      display: none;
+      margin-top: 1rem;
+      background: var(--youth-violet);
+      color: #fff;
+      border: none;
+      border-radius: 50px;
+      padding: 0.65rem 1.75rem;
+      font-family: inherit;
+      font-size: 0.95rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .btn-next-scenario:hover { background: #3d2566; }
+    .btn-next-scenario.visible { display: inline-flex; align-items: center; gap: 0.4rem; }
+
+    /* All-done block */
+    .scenarios-complete {
+      display: none;
+      text-align: center;
+      padding: 2rem 1rem;
+      background: var(--youth-violet-bg);
+      border-radius: 16px;
+      margin-bottom: 2rem;
+    }
+    .scenarios-complete.visible { display: block; }
+    .sc-icon { font-size: 3rem; margin-bottom: 0.75rem; }
+    .sc-score { font-size: 1.5rem; font-weight: 800; color: var(--youth-violet); }
+    .sc-sub { font-size: 1rem; color: var(--color-text-light,#50505F); margin-top: 0.4rem; }
+  </style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Skip to main content</a>
+
+  <div class="accessibility-bar" role="toolbar" aria-label="Accessibility controls">
+    <button class="a11y-btn font-size-btn" data-size="small" aria-label="Small text" aria-pressed="false" style="font-size:0.8rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="medium" aria-label="Medium text" aria-pressed="true" style="font-size:1rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="large" aria-label="Large text" aria-pressed="false" style="font-size:1.2rem">A</button>
+    <button class="a11y-btn font-size-btn" data-size="xl" aria-label="Extra large text" aria-pressed="false" style="font-size:1.4rem">A</button>
+    <button class="a11y-btn theme-toggle-btn" aria-label="Switch to dark mode">🌓</button>
+  </div>
+
+  <div class="top-bar">
+    <button class="menu-btn" aria-label="Open navigation menu">☰</button>
+    <span class="site-title">The Pressure You Can Name — Youth</span>
+    <span></span>
+  </div>
+
+  <div class="sidebar-overlay" aria-hidden="true"></div>
+  <aside class="sidebar" aria-label="Main navigation">
+    <button class="sidebar-close" aria-label="Close menu">Close &#10005;</button>
+    <div class="sidebar-header">
+      <h2>Digital Confidence Centre</h2>
+      <p>Youth Social Literacy</p>
+    </div>
+    <nav>
+      <a href="index.html"><span class="nav-icon" aria-hidden="true">🏠</span><span class="nav-label">Home</span></a>
+      <a href="digital-literacy-101.html"><span class="nav-icon" aria-hidden="true">📚</span><span class="nav-label">All Modules</span></a>
+      <a href="module-pressure-youth.html" aria-current="page"><span class="nav-icon" aria-hidden="true">🫷</span><span class="nav-label">The Pressure You Can Name (Youth)</span></a>
+      <a href="module-gems-youth.html"><span class="nav-icon" aria-hidden="true">💎</span><span class="nav-label">Gems Are Real Money (Youth)</span></a>
+      <a href="module-ai-literacy-youth.html"><span class="nav-icon" aria-hidden="true">🎯</span><span class="nav-label">AI in Real Life (Youth)</span></a>
+      <a href="module-ads-youth.html"><span class="nav-icon" aria-hidden="true">📣</span><span class="nav-label">Ads vs. Content (Youth)</span></a>
+      <a href="kids/index.html"><span class="nav-icon" aria-hidden="true">🧒</span><span class="nav-label">DCC Kids (Ages 4–12)</span></a>
+    </nav>
+  </aside>
+
+  <div class="page-wrapper">
+    <main class="main-content" id="main">
+
+      <div class="youth-hero">
+        <div class="eyebrow">Ages 12–18 · Social Pressure</div>
+        <h1>The Pressure You Can Name</h1>
+        <p>Guilt trips, group pile-ons, streak mechanics, and "if you were really my friend" — four real scenarios. When you can name the tactic, you can choose your own response.</p>
+      </div>
+
+      <div class="confidence-check-box">
+        ✅ <strong>This is a safe space to explore.</strong><br>
+        Nothing on this page can harm your device, there is no grade, and you cannot break anything. Question everything — that is the whole point.
+      </div>
+
+      <div class="coach-tip">
+        <div class="coach-tip__header">
+          <span class="coach-tip__icon" aria-hidden="true">❤️</span>
+          <span class="coach-tip__label">From your coach</span>
+        </div>
+        <p>Social pressure is designed to work fast. The moment you feel "everyone's doing it" or "if you really cared," that urgency is the tactic itself. Naming it — even just to yourself — buys the second you need to decide on your own terms. That is the whole skill.</p>
+      </div>
+
+      <!-- Before quiz -->
+      <div class="dcc-quiz-container" id="dcc-before-quiz" aria-label="Knowledge check — before you start" style="margin-bottom:2rem"></div>
+
+      <!-- Scenario progress -->
+      <div class="scenario-progress" id="scenarioProgress" role="progressbar" aria-label="Scenario progress" aria-valuenow="0" aria-valuemax="4">
+        <div class="progress-pip active" id="pip-0"></div>
+        <div class="progress-pip" id="pip-1"></div>
+        <div class="progress-pip" id="pip-2"></div>
+        <div class="progress-pip" id="pip-3"></div>
+        <span class="progress-label" id="progressLabel">Scenario 1 of 4</span>
+      </div>
+
+      <!-- Scenario 1 -->
+      <div class="scenario-card active" id="scenario-0" role="region" aria-label="Scenario 1: If You Were Really My Friend">
+        <div class="scenario-header">
+          <div class="scenario-num">1</div>
+          <div>
+            <div class="scenario-tag">Conditional Friendship</div>
+          </div>
+        </div>
+        <div class="scenario-body">
+          <div class="scenario-title">"If You Were Really My Friend..."</div>
+          <div class="scenario-story">
+            A 16-year-old has been close online friends with someone for about six months. One evening, the other person says: "If you really trusted me, you would share your live location with me." When she hesitates, they follow up: "Fine — I guess you never actually cared." She feels guilty. She also feels confused, because she does care.
+          </div>
+          <p class="scenario-question">When someone says "if you really cared about me, you would [do X]," what is most likely happening?</p>
+          <div class="answer-options" id="opts-0">
+            <button class="answer-btn" data-q="0" data-val="0"><span class="ans-letter">A</span> They are probably right — showing you care sometimes means doing what they ask</button>
+            <button class="answer-btn" data-q="0" data-val="1"><span class="ans-letter">B</span> This is a conditional threat — the relationship is being used as leverage to pressure a specific action</button>
+            <button class="answer-btn" data-q="0" data-val="2"><span class="ans-letter">C</span> It depends on how long you have known the person and how close you are</button>
+            <button class="answer-btn" data-q="0" data-val="3"><span class="ans-letter">D</span> The friendship has become unhealthy and should end immediately</button>
+          </div>
+          <div class="scenario-debrief" id="debrief-0">
+            <div class="debrief-label">Naming the conditional threat</div>
+            <p>Real care and real limits coexist. The phrase "if you really cared, you would" is a conditional threat — it ties the proof of your feelings to a specific action, making any limit you set look like a lack of care. This tactic works because it reframes "no" as evidence you don't care, rather than evidence that you have your own judgement. Noticing the structure — "comply or your care is questioned" — is the skill. Caring about someone and having your own limits are not in conflict. A friendship that requires you to overrule your own judgement to prove itself is asking for something real relationships do not ask for.</p>
+          </div>
+          <button class="btn-next-scenario" id="next-0" onclick="nextScenario(1)">Next scenario &#8594;</button>
+        </div>
+      </div>
+
+      <!-- Scenario 2 -->
+      <div class="scenario-card" id="scenario-1" role="region" aria-label="Scenario 2: The Group Pile-On">
+        <div class="scenario-header">
+          <div class="scenario-num">2</div>
+          <div>
+            <div class="scenario-tag">Social Coercion</div>
+          </div>
+        </div>
+        <div class="scenario-body">
+          <div class="scenario-title">The Group Pile-On</div>
+          <div class="scenario-story">
+            A 14-year-old is in a group chat where classmates are sharing screenshots from someone's private social account and laughing. Someone tags him: "Don't be the one who doesn't get it." Another person says "everyone's sharing it — it's just a joke." He is uncomfortable. He also does not want to be the person who says nothing or the person who says something wrong.
+          </div>
+          <p class="scenario-question">What is the most accurate description of what is happening in this group chat?</p>
+          <div class="answer-options" id="opts-1">
+            <button class="answer-btn" data-q="1" data-val="0"><span class="ans-letter">A</span> Normal humour — if most people are laughing, it is probably not serious</button>
+            <button class="answer-btn" data-q="1" data-val="1"><span class="ans-letter">B</span> He should forward it and then report the original content separately</button>
+            <button class="answer-btn" data-q="1" data-val="2"><span class="ans-letter">C</span> Peer pressure — social belonging is being used as leverage; "everyone else is doing it" is not a reason</button>
+            <button class="answer-btn" data-q="1" data-val="3"><span class="ans-letter">D</span> It only becomes a problem if the person whose content it is finds out</button>
+          </div>
+          <div class="scenario-debrief" id="debrief-1">
+            <div class="debrief-label">Peer pressure is not a reason</div>
+            <p>"Everyone else is doing it" describes what the group is doing. It does not tell you whether the thing is worth doing. Peer pressure works by making belonging conditional on participation — the implicit message is "comply or lose your place in the group." In Canadian schools, sharing someone's private content without consent can constitute cyberbullying under provincial codes of conduct and, depending on the content and age of the people involved, may cross into criminal territory under the Criminal Code of Canada. The clearest first move is to not forward the content. The group's judgement and your own judgement are two separate things — you can tell them apart when you slow down enough to notice the difference.</p>
+          </div>
+          <button class="btn-next-scenario" id="next-1" onclick="nextScenario(2)">Next scenario &#8594;</button>
+        </div>
+      </div>
+
+      <!-- Scenario 3 -->
+      <div class="scenario-card" id="scenario-2" role="region" aria-label="Scenario 3: The 200-Day Streak">
+        <div class="scenario-header">
+          <div class="scenario-num">3</div>
+          <div>
+            <div class="scenario-tag">Streak Mechanics</div>
+          </div>
+        </div>
+        <div class="scenario-body">
+          <div class="scenario-title">The 200-Day Streak</div>
+          <div class="scenario-story">
+            A 13-year-old and her best friend have a 214-day Snapchat streak. When she was sick for two days and could not send anything, her friend did not speak to her for a week. Now her friend texts: "Promise me you'll never let the streak break again. If you really want to stay best friends, you'll send something every single day no matter what." She feels like the app has become a daily test she could fail.
+          </div>
+          <p class="scenario-question">What is most accurately happening here?</p>
+          <div class="answer-options" id="opts-2">
+            <button class="answer-btn" data-q="2" data-val="0"><span class="ans-letter">A</span> App streaks are designed to keep you active — they measure platform engagement, not the quality of a friendship</button>
+            <button class="answer-btn" data-q="2" data-val="1"><span class="ans-letter">B</span> Her friend is right — a long streak shows real commitment</button>
+            <button class="answer-btn" data-q="2" data-val="2"><span class="ans-letter">C</span> She should ask Snapchat to restore the streak so the tension goes away</button>
+            <button class="answer-btn" data-q="2" data-val="3"><span class="ans-letter">D</span> This means the friendship matters more to one person than the other</button>
+          </div>
+          <div class="scenario-debrief" id="debrief-2">
+            <div class="debrief-label">Streak mechanics are app design, not friendship</div>
+            <p>Snapchat introduced streak mechanics specifically to drive daily active users — a metric that matters to the company's advertising business. The fire emoji and count are engagement tools. When those tools get attached to real friendship as proof of care, the app's commercial interest and your social life become tangled. Being sick for two days and missing a streak number is not evidence that a friendship matters less. A friendship that requires daily app activity to survive is partly a product of that design, not just of who the two of you are to each other. Recognising the streak for what it is — an app feature, not a relationship barometer — does not make the friendship less real; it just separates the two things.</p>
+          </div>
+          <button class="btn-next-scenario" id="next-2" onclick="nextScenario(3)">Next scenario &#8594;</button>
+        </div>
+      </div>
+
+      <!-- Scenario 4 -->
+      <div class="scenario-card" id="scenario-3" role="region" aria-label="Scenario 4: You Are the Only One Who Gets Me">
+        <div class="scenario-header">
+          <div class="scenario-num">4</div>
+          <div>
+            <div class="scenario-tag">Emotional Dependency</div>
+          </div>
+        </div>
+        <div class="scenario-body">
+          <div class="scenario-title">"You're the Only One Who Gets Me"</div>
+          <div class="scenario-story">
+            A 15-year-old has been messaging someone he met online for several months. The other person regularly sends long messages late at night describing how difficult their life is and says "you are the only person who really understands me." When he takes more than an hour to reply, they send "I guess I am too much for you too." He feels guilty. He starts checking his phone constantly. He has stopped spending as much time with his friends in person because he feels responsible.
+          </div>
+          <p class="scenario-question">What is this pattern called, and what is the healthy understanding of it?</p>
+          <div class="answer-options" id="opts-3">
+            <button class="answer-btn" data-q="3" data-val="0"><span class="ans-letter">A</span> A sign of deep trust — being the person someone relies on is part of a close friendship</button>
+            <button class="answer-btn" data-q="3" data-val="1"><span class="ans-letter">B</span> Loneliness — not a manipulation tactic, just someone who needs support</button>
+            <button class="answer-btn" data-q="3" data-val="2"><span class="ans-letter">C</span> Emotional enmeshment — using vulnerability as leverage to create guilt and a sense of personal responsibility for another person's wellbeing</button>
+            <button class="answer-btn" data-q="3" data-val="3"><span class="ans-letter">D</span> Normal online friendship — people share more openly in text than in person</button>
+          </div>
+          <div class="scenario-debrief" id="debrief-3">
+            <div class="debrief-label">Care without responsibility</div>
+            <p>Emotional enmeshment is a pattern where someone uses their own pain or vulnerability to bind another person to them through guilt. "You are the only one" places the entire weight of their emotional state on one person — who then feels that any limit they set causes real harm. The fact that someone is genuinely struggling does not make this pattern healthy or fair to either person. The sustainable response is: caring about someone and being responsible for their emotional state are two different things. A 15-year-old is not equipped to be another person's only support — and being placed in that role is a form of pressure, not a compliment. Kids Help Phone (1-800-668-6868, online at kidshelpphone.ca) exists for exactly this kind of situation — the person struggling can reach trained counsellors who are actually equipped to help.</p>
+          </div>
+          <button class="btn-next-scenario" id="next-3" onclick="completedScenarios()">See your results &#8594;</button>
+        </div>
+      </div>
+
+      <!-- All scenarios complete -->
+      <div class="scenarios-complete" id="scenariosComplete" role="status" aria-live="polite">
+        <div class="sc-icon">🫷</div>
+        <div class="sc-score" id="scenarioScore">0 / 4 correct</div>
+        <div class="sc-sub" id="scenarioSub">Complete the after quiz below to see your full results.</div>
+      </div>
+
+      <!-- After quiz -->
+      <div class="dcc-quiz-container" id="dcc-after-quiz" aria-label="Knowledge check — after the scenarios" style="margin:2rem 0"></div>
+
+      <!-- Success state -->
+      <div class="tip-block" style="border-left-color:var(--youth-violet);background:var(--youth-violet-bg)" role="note">
+        <span class="tip-label" style="color:var(--youth-violet)">&#10003; Success State — What a completed module looks like</span>
+        <p>When you have finished:</p>
+        <ul style="margin:0.5rem 0 0;padding-left:1.25rem;line-height:2">
+          <li>The "Quick Check — Before You Start" section above shows <strong>Recorded</strong></li>
+          <li>All four scenario cards show a debrief — you have worked through each one</li>
+          <li>The "Quick Check — After" shows your score and delta</li>
+          <li>You can name at least one pressure tactic the next time you notice it</li>
+        </ul>
+      </div>
+
+      <section class="related-modules" aria-label="Related modules">
+        <h3 class="related-title">Keep Going</h3>
+        <div class="related-grid">
+          <a href="module-gems-youth.html" class="related-card">
+            <span class="related-num">Youth</span>
+            <span class="related-name">Gems Are Real Money (Youth)</span>
+            <span class="related-desc">V-Bucks, Robux, loot boxes, and artificial scarcity — the dark patterns that turn screen time into spending without you noticing.</span>
+          </a>
+          <a href="module-ads-youth.html" class="related-card">
+            <span class="related-num">Youth</span>
+            <span class="related-name">Ads vs. Content (Youth)</span>
+            <span class="related-desc">How to tell the difference between organic content and paid promotion — especially when influencers and algorithms blur the line.</span>
+          </a>
+        </div>
+      </section>
+
+      <div class="module-nav-footer">
+        <a href="module-gems-youth.html" class="module-nav-prev">&#8592; Gems Are Real Money (Youth)</a>
+        <a href="digital-literacy-101.html" class="module-nav-next">All Modules &#8594;</a>
+      </div>
+
+    </main>
+  </div>
+
+  <footer class="site-footer" role="contentinfo" aria-label="Site footer">
+    <div class="footer-inner">
+      <nav class="footer-links" aria-label="Footer links">
+        <a href="index.html">Home</a> |
+        <a href="digital-literacy-101.html">Modules</a> |
+        <a href="resources/index.html">Resources</a> |
+        <a href="kids/index.html">Kids</a> |
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footer-copy">&copy; 2026 Two Birds Innovation. Made with care in Ontario, Canada.</p>
+    </div>
+  </footer>
+
+  <script src="js/speech-config.js" defer></script>
+  <script src="js/read-aloud.js" defer></script>
+  <script src="js/app.js" defer></script>
+  <script src="js/lang-toggle.js" defer></script>
+  <script src="js/accessibility.js" defer></script>
+  <script src="js/focus-mode.js" defer></script>
+  <script src="js/small-wins.js" defer></script>
+  <script src="js/badges.js" defer></script>
+  <script src="js/settings.js" defer></script>
+  <script src="js/quiz-check.js" defer></script>
+  <script src="js/measurement.js" defer></script>
+  <script>
+  // Correct answers for the 4 interactive scenarios (0-indexed option)
+  // Scenario 1: B=1 (conditional threat), 2: C=2 (peer pressure), 3: A=0 (streak mechanics), 4: C=2 (enmeshment)
+  var SCENARIO_CORRECT = [1, 2, 0, 2];
+  var scenarioAnswered  = [false, false, false, false];
+  var scenarioCorrect   = [false, false, false, false];
+
+  function answerScenario(q, val) {
+    if (scenarioAnswered[q]) return;
+    scenarioAnswered[q] = true;
+    var correct = val === SCENARIO_CORRECT[q];
+    scenarioCorrect[q] = correct;
+
+    var opts = document.querySelectorAll('[data-q="' + q + '"]');
+    opts.forEach(function(btn) {
+      btn.disabled = true;
+      var bval = parseInt(btn.dataset.val, 10);
+      if (bval === SCENARIO_CORRECT[q]) btn.classList.add(correct ? 'selected-correct' : 'reveal-correct');
+      if (!correct && bval === val) btn.classList.add('selected-wrong');
+    });
+
+    var debrief = document.getElementById('debrief-' + q);
+    if (debrief) debrief.classList.add('visible');
+
+    var next = document.getElementById('next-' + q);
+    if (next) next.classList.add('visible');
+
+    updateProgress(q);
+  }
+
+  function nextScenario(idx) {
+    var current = document.getElementById('scenario-' + (idx - 1));
+    var next = document.getElementById('scenario-' + idx);
+    if (current) current.classList.remove('active');
+    if (next) next.classList.add('active');
+    updateProgress(idx);
+    if (next) next.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function completedScenarios() {
+    var current = document.getElementById('scenario-3');
+    if (current) current.classList.remove('active');
+    var done = document.getElementById('scenariosComplete');
+    var scoreEl = document.getElementById('scenarioScore');
+    var subEl   = document.getElementById('scenarioSub');
+    var total = scenarioCorrect.filter(Boolean).length;
+    if (scoreEl) scoreEl.textContent = total + ' / 4 correct';
+    var msg = total === 4 ? 'Perfect — you named every tactic.'
+            : total >= 3 ? 'Strong — one to review in the debriefs.'
+            : total >= 2 ? 'Good start — look back at the debriefs for the ones you missed.'
+            : 'Review the debriefs above, then take the after quiz.';
+    if (subEl) subEl.textContent = msg + ' Complete the after quiz below to see your full results.';
+    if (done) { done.classList.add('visible'); done.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
+
+    if (window.DCC_QUIZ) {
+      var record = {};
+      scenarioCorrect.forEach(function(v, i) { record['scenario_' + (i+1)] = v ? 1 : 0; });
+      record.scenario_total = total;
+      try {
+        var all = JSON.parse(localStorage.getItem('dcc_quiz_results') || '{}');
+        all['module-pressure-youth'] = Object.assign(all['module-pressure-youth'] || {}, { scenarios: record });
+        localStorage.setItem('dcc_quiz_results', JSON.stringify(all));
+      } catch(e) {}
+    }
+  }
+
+  function updateProgress(current) {
+    for (var i = 0; i < 4; i++) {
+      var pip = document.getElementById('pip-' + i);
+      if (!pip) continue;
+      pip.classList.remove('done', 'active');
+      if (i < current) pip.classList.add('done');
+      else if (i === current) pip.classList.add('active');
+    }
+    var label = document.getElementById('progressLabel');
+    if (label) label.textContent = current < 4 ? 'Scenario ' + (current + 1) + ' of 4' : 'All scenarios done';
+  }
+
+  document.addEventListener('click', function(e) {
+    var btn = e.target.closest('.answer-btn[data-q]');
+    if (!btn) return;
+    var q = parseInt(btn.dataset.q, 10);
+    var val = parseInt(btn.dataset.val, 10);
+    answerScenario(q, val);
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    var QUESTIONS = [
+      {
+        text: 'When someone says "if you really cared about me, you would [do X]," this is an example of:',
+        text_after: 'After the scenarios — "if you really cared, you would [do X]" is best described as:',
+        options: [
+          'Honest communication — telling someone what they need',
+          'A conditional threat that uses the relationship as leverage to pressure a specific action',
+          'A reasonable expectation in any close friendship',
+          'A cultural difference in how people express care'
+        ],
+        correct: 1
+      },
+      {
+        text: 'A group is pressuring you to do something by saying "everyone else is fine with it." What should you recognize?',
+        text_after: 'After the scenarios — "everyone else is doing it" is:',
+        options: [
+          'A good reason to reconsider — social consensus often reflects what is right',
+          'A sign the group does not really know you',
+          'Peer pressure — the fact that others are doing something is not a reason for you to do it',
+          'An invitation to discuss the issue openly with the group'
+        ],
+        correct: 2
+      },
+      {
+        text: 'A close friend says "if you break our streak I will be devastated." App streak mechanics:',
+        text_after: 'App streaks that create emotional obligation are:',
+        options: [
+          'A meaningful way to track how close a friendship is',
+          'Designed to keep you active on the app — not a measure of friendship quality',
+          'A fun tradition that only becomes a problem if both people stop enjoying them',
+          'A form of cyberbullying if used to create pressure'
+        ],
+        correct: 1
+      },
+      {
+        text: 'Someone says "you are the only one who understands me" and becomes angry when you take too long to reply. This pattern is:',
+        text_after: 'Using vulnerability ("you\'re the only one who gets me") to make someone feel guilty is:',
+        options: [
+          'Deep trust — a sign that someone truly values the relationship',
+          'Loneliness — not a manipulation tactic, just someone who needs support',
+          'Emotional enmeshment — using personal pain as leverage to create guilt and obligation',
+          'Normal for online friendships where people share more openly'
+        ],
+        correct: 2
+      },
+      {
+        text: 'When you can name a pressure tactic — "this is a conditional threat," "this is peer pressure" — the healthiest first step is:',
+        text_after: 'After the scenarios — naming a pressure tactic gives you:',
+        options: [
+          'Apologize and comply — it reduces conflict and shows you care',
+          'Cut off contact immediately to protect yourself',
+          'Match the person\'s emotional intensity so they understand how you feel',
+          'A second to decide on your own terms — the urgency the tactic creates is the tactic'
+        ],
+        correct: 3
+      }
+    ];
+
+    if (window.DCC_QUIZ) {
+      DCC_QUIZ.init({
+        moduleId: 'module-pressure-youth',
+        questions: QUESTIONS,
+        beforeContainerId: 'dcc-before-quiz',
+        afterContainerId:  'dcc-after-quiz'
+      });
+    }
+  });
+  </script>
+
+</body>
+</html>

--- a/module-template.html
+++ b/module-template.html
@@ -364,7 +364,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/module-visual-ai.html
+++ b/module-visual-ai.html
@@ -217,7 +217,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/print-centre.html
+++ b/print-centre.html
@@ -435,7 +435,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/recommended-tools.html
+++ b/recommended-tools.html
@@ -341,7 +341,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources.html
+++ b/resources.html
@@ -218,7 +218,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/age-amount-credit.html
+++ b/resources/age-amount-credit.html
@@ -84,7 +84,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/ai-tools-seniors.html
+++ b/resources/ai-tools-seniors.html
@@ -124,7 +124,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/allowance-allowance-for-survivor.html
+++ b/resources/allowance-allowance-for-survivor.html
@@ -113,7 +113,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/canada-caregiver-credit.html
+++ b/resources/canada-caregiver-credit.html
@@ -108,7 +108,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/canada-workers-benefit.html
+++ b/resources/canada-workers-benefit.html
@@ -84,7 +84,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/canadian-helplines.html
+++ b/resources/canadian-helplines.html
@@ -97,7 +97,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/cpp-death-benefit.html
+++ b/resources/cpp-death-benefit.html
@@ -128,7 +128,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/cpp-start-date-guide.html
+++ b/resources/cpp-start-date-guide.html
@@ -113,7 +113,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/cpp-survivors-pension.html
+++ b/resources/cpp-survivors-pension.html
@@ -113,7 +113,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/cra-guide.html
+++ b/resources/cra-guide.html
@@ -134,7 +134,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/dental-care-guide.html
+++ b/resources/dental-care-guide.html
@@ -113,7 +113,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/device-guides.html
+++ b/resources/device-guides.html
@@ -89,7 +89,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/digital-safety-seniors-ontario.html
+++ b/resources/digital-safety-seniors-ontario.html
@@ -190,7 +190,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/disability-tax-credit.html
+++ b/resources/disability-tax-credit.html
@@ -108,7 +108,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/gis-guide.html
+++ b/resources/gis-guide.html
@@ -113,7 +113,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/glossary-by-topic.html
+++ b/resources/glossary-by-topic.html
@@ -219,7 +219,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/gst-hst-credit.html
+++ b/resources/gst-hst-credit.html
@@ -113,7 +113,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/home-accessibility-tax-credit.html
+++ b/resources/home-accessibility-tax-credit.html
@@ -108,7 +108,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/how-to-spot-scams-canada.html
+++ b/resources/how-to-spot-scams-canada.html
@@ -122,7 +122,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/index.html
+++ b/resources/index.html
@@ -181,7 +181,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/ipad-basics-seniors.html
+++ b/resources/ipad-basics-seniors.html
@@ -122,7 +122,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/medical-expense-tax-credit.html
+++ b/resources/medical-expense-tax-credit.html
@@ -108,7 +108,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/myth-busters.html
+++ b/resources/myth-busters.html
@@ -195,7 +195,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/oas-deferral-guide.html
+++ b/resources/oas-deferral-guide.html
@@ -108,7 +108,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/online-banking-safety-canada.html
+++ b/resources/online-banking-safety-canada.html
@@ -121,7 +121,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/ontario-drug-benefit.html
+++ b/resources/ontario-drug-benefit.html
@@ -113,7 +113,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/ontario-property-tax-grant.html
+++ b/resources/ontario-property-tax-grant.html
@@ -84,7 +84,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/ontario-seniors-care-at-home-credit.html
+++ b/resources/ontario-seniors-care-at-home-credit.html
@@ -129,7 +129,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/ontario-trillium-benefit.html
+++ b/resources/ontario-trillium-benefit.html
@@ -108,7 +108,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/pension-income-splitting.html
+++ b/resources/pension-income-splitting.html
@@ -84,7 +84,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/registered-disability-savings-plan.html
+++ b/resources/registered-disability-savings-plan.html
@@ -129,7 +129,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/rrsp-rrif-guide.html
+++ b/resources/rrsp-rrif-guide.html
@@ -108,7 +108,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/service-canada-guide.html
+++ b/resources/service-canada-guide.html
@@ -132,7 +132,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/serviceontario-guide.html
+++ b/resources/serviceontario-guide.html
@@ -127,7 +127,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/subscription-traps.html
+++ b/resources/subscription-traps.html
@@ -129,7 +129,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/support-directory.html
+++ b/resources/support-directory.html
@@ -283,7 +283,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/resources/video-calling-grandchildren.html
+++ b/resources/video-calling-grandchildren.html
@@ -124,7 +124,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/scam-alerts/index.html
+++ b/scam-alerts/index.html
@@ -148,7 +148,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/scam-simulator.html
+++ b/scam-simulator.html
@@ -243,7 +243,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/videos/module-1-intro.html
+++ b/videos/module-1-intro.html
@@ -478,7 +478,7 @@
         <a href="../module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="../module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="../module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="../module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>

--- a/whats-coming.html
+++ b/whats-coming.html
@@ -205,7 +205,7 @@
         <a href="module-visual-ai.html"><span class="nav-icon" aria-hidden="true">📷</span><span class="nav-label">Show Me! (Bonus)</span></a>
       </details>
       <details class="snav-group">
-        <summary class="snav-header">Living Independently</summary>
+        <summary class="snav-header">Staying Independent</summary>
         <a href="module-16-travel-safety.html"><span class="nav-icon" aria-hidden="true">✈️</span><span class="nav-label">16. Travel Safety</span></a>
         <a href="module-17-ai-research.html"><span class="nav-icon" aria-hidden="true">🔍</span><span class="nav-label">17. AI Research</span></a>
         <a href="module-18-staying-connected.html"><span class="nav-icon" aria-hidden="true">💞</span><span class="nav-label">18. Staying Connected</span></a>


### PR DESCRIPTION
## Summary
- S-DCC-INTERACTION-FIX: Remove redundant B4 teal help circle, null-guard sidebar keydown, move speech stop button to avoid overlap, fix WCAG touch target on ? Help button, standardise close buttons to canonical ✕ format
- S-NHSP-PITCH-PAGE: institutional.html 2026-27 NHSP deadline updates + $50K budget model
- D7: Rename sidebar group "Living Independently" → "Staying Independent"
- Youth pressure module: The Pressure You Can Name (ages 12-18, in-game currency dark patterns)
- Batch-3 module migration: modules 21-27 + named AI modules onto shared design system
- DCC-v4 CSS/token refinements from batch-3 sprint

## Test plan
- [ ] Live site smoke-test: `twobirds-kramerica.github.io/digital-confidence/module-1.html` — no overlapping buttons in bottom-right corner
- [ ] Speech read-aloud active: stop button at right:88px, feedback FAB at right:16px — no overlap
- [ ] Escape key closes sidebar on module pages
- [ ] `? Help` button height ≥44px (WCAG 2.5.5)
- [ ] Scam modal + feedback modal close button shows `Close ✕`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WL95njjS4Y5CqGgQimsNk